### PR TITLE
Fix hashing overflow

### DIFF
--- a/Sources/FirebladeECS/ComponentIdentifier.swift
+++ b/Sources/FirebladeECS/ComponentIdentifier.swift
@@ -10,7 +10,7 @@ public struct ComponentIdentifier {
     @usableFromInline
     typealias Hash = Int
     @usableFromInline
-    typealias StableId = UInt
+    typealias StableId = UInt64
 
     @usableFromInline let hash: Hash
 }

--- a/Sources/FirebladeECS/Hashing.swift
+++ b/Sources/FirebladeECS/Hashing.swift
@@ -90,11 +90,11 @@ public enum StringHashing {
     /// *Waren Singer djb2*
     ///
     /// <https://stackoverflow.com/a/43149500>
-    public static func singer_djb2(_ utf8String: String) -> UInt {
-        var hash = UInt(5381)
+    public static func singer_djb2(_ utf8String: String) -> UInt64 {
+        var hash = UInt64(5381)
         var iter = utf8String.unicodeScalars.makeIterator()
         while let char = iter.next() {
-            hash &= 127 * (hash & 0x00ffffffffffffff) &+ UInt(char.value)
+            hash = 127 * (hash & 0x00ffffffffffffff) &+ UInt64(char.value)
         }
         return hash
     }

--- a/Sources/FirebladeECS/Hashing.swift
+++ b/Sources/FirebladeECS/Hashing.swift
@@ -94,7 +94,7 @@ public enum StringHashing {
         var hash = UInt(5381)
         var iter = utf8String.unicodeScalars.makeIterator()
         while let char = iter.next() {
-            hash = 127 * (hash & 0x00ffffffffffffff) + UInt(char.value)
+            hash &= 127 * (hash & 0x00ffffffffffffff) &+ UInt(char.value)
         }
         return hash
     }


### PR DESCRIPTION
Hello! Thank you for a fantastic and well-architected library, I love the approach.

Though I think anyone using this library is likely targeting 64-bit devices only, when targeting iOS 11, building for the generic iOS device produces an overflow error. This is strange because iOS 11 only supports 64-bit devices; I think the standard architecture still includes 32-bit, though I cannot figure out how/why.

<img width="714" alt="overflow" src="https://user-images.githubusercontent.com/453578/87005394-c80e4680-c173-11ea-856c-8b5e1795a6ef.png">

Changing this hash function and `StableId` to use an explicit UInt64 avoids the error,  and it should not use any more memory, because `UInt` will always be 64-bit for 64-bit devices anyway.