### PR TITLE
Fix key-index in UnorderedSparseSet

### DIFF
--- a/Sources/FirebladeECS/UnorderedSparseSet.swift
+++ b/Sources/FirebladeECS/UnorderedSparseSet.swift
@@ -15,7 +15,7 @@ public struct UnorderedSparseSet<Element> {
     }
 
     @usableFromInline var dense: ContiguousArray<Entry>
-    @usableFromInline var sparse: [Index: Key]
+    @usableFromInline var sparse: [Key: Index]
 
     public init() {
         self.init(sparse: [:], dense: [])


### PR DESCRIPTION
This is something of a nitpick / typo fix :)

I believe these two should be reversed. It currently works fine for Fireblade ECS because both `Key` and `Index` are aliased to `Int`, but it would break if this data structure was subclassed and used for a different purpose, e.g. if `Key` was a `String` instead.
