### PR TITLE
Fix hashing overflow - follow up

### DIFF
--- a/Sources/FirebladeECS/ComponentIdentifier.swift
+++ b/Sources/FirebladeECS/ComponentIdentifier.swift
@@ -10,7 +10,7 @@ public struct ComponentIdentifier {
     @usableFromInline
     typealias Hash = Int
     @usableFromInline
-    typealias StableId = UInt
+    typealias StableId = UInt64
 
     @usableFromInline let hash: Hash
 }

--- a/Sources/FirebladeECS/Hashing.swift
+++ b/Sources/FirebladeECS/Hashing.swift
@@ -91,10 +91,10 @@ public enum StringHashing {
     ///
     /// <https://stackoverflow.com/a/43149500>
     public static func singer_djb2(_ utf8String: String) -> UInt64 {
-        var hash = UInt64(5381)
+        var hash: UInt64 = 5381
         var iter = utf8String.unicodeScalars.makeIterator()
         while let char = iter.next() {
-            hash = 127 * (hash & 0x00ffffffffffffff) &+ UInt64(char.value)
+            hash = 127 * (hash & 0xFFFFFFFFFFFFFF) &+ UInt64(char.value)
         }
         return hash
     }
@@ -106,11 +106,11 @@ public enum StringHashing {
     /// The magic of number 33 (why it works better than many other constants, prime or not) has never been adequately explained.
     ///
     /// <http://www.cse.yorku.ca/~oz/hash.html>
-    public static func bernstein_djb2(_ string: String) -> UInt {
-        var hash: UInt = 5381
+    public static func bernstein_djb2(_ string: String) -> UInt64 {
+        var hash: UInt64 = 5381
         var iter = string.unicodeScalars.makeIterator()
         while let char = iter.next() {
-            hash = (hash << 5) &+ hash &+ UInt(char.value)
+            hash = (hash << 5) &+ hash &+ UInt64(char.value)
         }
         return hash
     }
@@ -122,11 +122,11 @@ public enum StringHashing {
     /// It also happens to be a good general hashing function with good distribution.
     ///
     /// <http://www.cse.yorku.ca/~oz/hash.html>
-    public static func sdbm(_ string: String) -> UInt {
-        var hash: UInt = 0
+    public static func sdbm(_ string: String) -> UInt64 {
+        var hash: UInt64 = 0
         var iter = string.unicodeScalars.makeIterator()
         while let char = iter.next() {
-            hash = (UInt(char.value) &+ (hash << 6) &+ (hash << 16))
+            hash = (UInt64(char.value) &+ (hash << 6) &+ (hash << 16))
         }
         return hash
     }

--- a/Sources/FirebladeECS/Hashing.swift
+++ b/Sources/FirebladeECS/Hashing.swift
@@ -90,11 +90,11 @@ public enum StringHashing {
     /// *Waren Singer djb2*
     ///
     /// <https://stackoverflow.com/a/43149500>
-    public static func singer_djb2(_ utf8String: String) -> UInt {
-        var hash = UInt(5381)
+    public static func singer_djb2(_ utf8String: String) -> UInt64 {
+        var hash = UInt64(5381)
         var iter = utf8String.unicodeScalars.makeIterator()
         while let char = iter.next() {
-            hash &= 127 * (hash & 0x00ffffffffffffff) &+ UInt(char.value)
+            hash = 127 * (hash & 0x00ffffffffffffff) &+ UInt64(char.value)
         }
         return hash
     }

--- a/Sources/FirebladeECS/Hashing.swift
+++ b/Sources/FirebladeECS/Hashing.swift
@@ -94,7 +94,7 @@ public enum StringHashing {
         var hash = UInt(5381)
         var iter = utf8String.unicodeScalars.makeIterator()
         while let char = iter.next() {
-            hash = 127 * (hash & 0x00ffffffffffffff) + UInt(char.value)
+            hash &= 127 * (hash & 0x00ffffffffffffff) &+ UInt(char.value)
         }
         return hash
     }

--- a/Sources/FirebladeECS/Hashing.swift
+++ b/Sources/FirebladeECS/Hashing.swift
@@ -5,9 +5,9 @@
 //  Created by Christian Treffs on 16.10.17.
 //
 
-#if arch(x86_64) || arch(arm64) // 64 bit
+#if arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) // 64 bit
 private let kFibA: UInt = 0x9e3779b97f4a7c15 // = 11400714819323198485 aka Fibonacci Hash a value for 2^64; calculate by: 2^64 / (golden ratio)
-#elseif arch(i386) || arch(arm) // 32 bit
+#elseif arch(i386) || arch(arm) || os(watchOS) // 32 bit
 private let kFibA: UInt = 0x9e3779b9 // = 2654435769 aka Fibonacci Hash a value for 2^32; calculate by: 2^32 / (golden ratio)
 #else
 #error("unsupported architecture")

--- a/Sources/FirebladeECS/Hashing.swift
+++ b/Sources/FirebladeECS/Hashing.swift
@@ -85,7 +85,7 @@ extension EntityComponentHash {
 }
 
 // MARK: - string hashing
-/// https://stackoverflow.com/a/52440609
+/// <https://stackoverflow.com/a/52440609>
 public enum StringHashing {
     /// *Waren Singer djb2*
     ///
@@ -111,7 +111,6 @@ public enum StringHashing {
         var iter = string.unicodeScalars.makeIterator()
         while let char = iter.next() {
             hash = (hash << 5) &+ hash &+ UInt(char.value)
-            //hash = ((hash << 5) + hash) + UInt(c.value)
         }
         return hash
     }

--- a/Tests/FirebladeECSPerformanceTests/HashingPerformanceTests.swift
+++ b/Tests/FirebladeECSPerformanceTests/HashingPerformanceTests.swift
@@ -13,9 +13,9 @@ class HashingPerformanceTests: XCTestCase {
     /// release:  0.726 sec
     /// debug:    3.179 sec
     func testMeasureCombineHash() {
-        let a: Set<Int> = Set<Int>([14_561_291, 26_451_562, 34_562_182, 488_972_556, 5_128_426_962, 68_211_812])
-        let b: Set<Int> = Set<Int>([1_083_838, 912_312, 83_333, 71_234_555, 4_343_234])
-        let c: Set<Int> = Set<Int>([3_410_346_899_765, 90_000_002, 12_212_321, 71, 6_123_345_676_543])
+        let a = Set<Int64>([14_561_291, 26_451_562, 34_562_182, 488_972_556, 5_128_426_962, 68_211_812])
+        let b = Set<Int64>([1_083_838, 912_312, 83_333, 71_234_555, 4_343_234])
+        let c = Set<Int64>([3_410_346_899_765, 90_000_002, 12_212_321, 71, 6_123_345_676_543])
 
         let input: ContiguousArray<Int> = ContiguousArray<Int>(arrayLiteral: a.hashValue, b.hashValue, c.hashValue)
         measure {
@@ -29,11 +29,11 @@ class HashingPerformanceTests: XCTestCase {
     /// release: 0.494 sec
     /// debug:   1.026 sec
     func testMeasureSetOfSetHash() {
-        let a: Set<Int> = Set<Int>([14_561_291, 26_451_562, 34_562_182, 488_972_556, 5_128_426_962, 68_211_812])
-        let b: Set<Int> = Set<Int>([1_083_838, 912_312, 83_333, 71_234_555, 4_343_234])
-        let c: Set<Int> = Set<Int>([3_410_346_899_765, 90_000_002, 12_212_321, 71, 6_123_345_676_543])
+        let a = Set<Int64>([14_561_291, 26_451_562, 34_562_182, 488_972_556, 5_128_426_962, 68_211_812])
+        let b = Set<Int64>([1_083_838, 912_312, 83_333, 71_234_555, 4_343_234])
+        let c = Set<Int64>([3_410_346_899_765, 90_000_002, 12_212_321, 71, 6_123_345_676_543])
 
-        let input = Set<Set<Int>>(arrayLiteral: a, b, c)
+        let input = Set<Set<Int64>>(arrayLiteral: a, b, c)
         measure {
             for _ in 0..<1_000_000 {
                 let hash: Int = input.hashValue


### PR DESCRIPTION
This PR is a follow up to https://github.com/fireblade-engine/ecs/pull/9.

Fixes:
- hashing overflow on non 64-bit architectures
- migration to UInt64 as string hashing base type
- extension of supported architectures