### PR TITLE
Add family.createMember()

### DIFF
--- a/Sources/FirebladeECS/Family.swift
+++ b/Sources/FirebladeECS/Family.swift
@@ -184,3 +184,17 @@ extension Family {
 }
 
 extension Family.RelativesIterator: LazySequenceProtocol { }
+
+// MARK: - member creation
+extension Family {
+    /// Create a new entity with components required by this family.
+    ///
+    /// Since the created entity will meet the requirements of this family it
+    /// will automatically become member of this family.
+    /// - Parameter components: The components required by this family.
+    /// - Returns: The newly created entity.
+    @discardableResult
+    public func createMember(with components: R.Components) -> Entity {
+        R.createMember(nexus: nexus, components: components)
+    }
+}

--- a/Sources/FirebladeECS/Family1.swift
+++ b/Sources/FirebladeECS/Family1.swift
@@ -30,6 +30,10 @@ public struct Requires1<A>: FamilyRequirementsManaging where A: Component {
         let childCompA: A = nexus.get(unsafeComponentFor: childId)
         return (parent: parentCompA, child: childCompA)
     }
+
+    public static func createMember(nexus: Nexus, components: A) -> Entity {
+        nexus.createEntity(with: components)
+    }
 }
 
 extension Nexus {

--- a/Sources/FirebladeECS/Family2.swift
+++ b/Sources/FirebladeECS/Family2.swift
@@ -15,6 +15,7 @@ public struct Requires2<A, B>: FamilyRequirementsManaging where A: Component, B:
     public init(_ components: (A.Type, B.Type)) {
         componentTypes = [ A.self, B.self]
     }
+
     public static func components(nexus: Nexus, entityId: EntityIdentifier) -> (A, B) {
         let compA: A = nexus.get(unsafeComponentFor: entityId)
         let compB: B = nexus.get(unsafeComponentFor: entityId)
@@ -34,6 +35,10 @@ public struct Requires2<A, B>: FamilyRequirementsManaging where A: Component, B:
         let ccA: A = nexus.get(unsafeComponentFor: childId)
         let ccB: B = nexus.get(unsafeComponentFor: childId)
         return (parent: (pcA, pcB), child: (ccA, ccB))
+    }
+
+    public static func createMember(nexus: Nexus, components: (A, B)) -> Entity {
+        nexus.createEntity(with: components.0, components.1)
     }
 }
 

--- a/Sources/FirebladeECS/Family3.swift
+++ b/Sources/FirebladeECS/Family3.swift
@@ -40,6 +40,10 @@ public struct Requires3<A, B, C>: FamilyRequirementsManaging where A: Component,
             let ccC: C = nexus.get(unsafeComponentFor: childId)
             return (parent: (pcA, pcB, pcC), child: (ccA, ccB, ccC))
     }
+
+    public static func createMember(nexus: Nexus, components: (A, B, C)) -> Entity {
+        nexus.createEntity(with: components.0, components.1, components.2)
+    }
 }
 
 extension Nexus {

--- a/Sources/FirebladeECS/Family4.swift
+++ b/Sources/FirebladeECS/Family4.swift
@@ -45,6 +45,10 @@ public struct Requires4<A, B, C, D>: FamilyRequirementsManaging where A: Compone
             let ccD: D = nexus.get(unsafeComponentFor: childId)
             return (parent: (pcA, pcB, pcC, pcD), child: (ccA, ccB, ccC, ccD))
     }
+
+    public static func createMember(nexus: Nexus, components: (A, B, C, D)) -> Entity {
+        nexus.createEntity(with: components.0, components.1, components.2, components.3)
+    }
 }
 
 extension Nexus {

--- a/Sources/FirebladeECS/Family5.swift
+++ b/Sources/FirebladeECS/Family5.swift
@@ -50,6 +50,10 @@ public struct Requires5<A, B, C, D, E>: FamilyRequirementsManaging where A: Comp
             return (parent: (pcA, pcB, pcC, pcD, pcE),
                     child: (ccA, ccB, ccC, ccD, ccE))
     }
+
+    public static func createMember(nexus: Nexus, components: (A, B, C, D, E)) -> Entity {
+        nexus.createEntity(with: components.0, components.1, components.2, components.3, components.4)
+    }
 }
 
 extension Nexus {

--- a/Sources/FirebladeECS/FamilyRequirementsManaging.swift
+++ b/Sources/FirebladeECS/FamilyRequirementsManaging.swift
@@ -18,4 +18,6 @@ public protocol FamilyRequirementsManaging {
     static func components(nexus: Nexus, entityId: EntityIdentifier) -> Components
     static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> EntityAndComponents
     static func relativesDescending(nexus: Nexus, parentId: EntityIdentifier, childId: EntityIdentifier) -> RelativesDescending
+
+    static func createMember(nexus: Nexus, components: Components) -> Entity
 }

--- a/Tests/FirebladeECSTests/FamilyTests.swift
+++ b/Tests/FirebladeECSTests/FamilyTests.swift
@@ -184,4 +184,37 @@ class FamilyTests: XCTestCase {
 
         XCTAssertEqual(family.memberIds.count, count + (count / 2))
     }
+
+    func testFamilyCreateMembers() {
+        let position = Position(x: 0, y: 1)
+        let name = Name(name: "SomeName")
+        let velocity = Velocity(a: 123)
+        let party = Party(partying: true)
+        let color = Color()
+
+        let family1 = nexus.family(requires: Position.self, excludesAll: Name.self)
+        XCTAssertTrue(family1.isEmpty)
+        family1.createMember(with: position)
+        XCTAssertEqual(family1.count, 1)
+
+        let family2 = nexus.family(requiresAll: Position.self, Name.self)
+        XCTAssertTrue(family2.isEmpty)
+        family2.createMember(with: (position, name))
+        XCTAssertEqual(family2.count, 1)
+
+        let family3 = nexus.family(requiresAll: Position.self, Name.self, Velocity.self)
+        XCTAssertTrue(family3.isEmpty)
+        family3.createMember(with: (position, name, velocity))
+        XCTAssertEqual(family3.count, 1)
+
+        let family4 = nexus.family(requiresAll: Position.self, Name.self, Velocity.self, Party.self)
+        XCTAssertTrue(family4.isEmpty)
+        family4.createMember(with: (position, name, velocity, party))
+        XCTAssertEqual(family4.count, 1)
+
+        let family5 = nexus.family(requiresAll: Position.self, Name.self, Velocity.self, Party.self, Color.self)
+        XCTAssertTrue(family5.isEmpty)
+        family5.createMember(with: (position, name, velocity, party, color))
+        XCTAssertEqual(family5.count, 1)
+    }
 }

--- a/Tests/FirebladeECSTests/XCTestManifests.swift
+++ b/Tests/FirebladeECSTests/XCTestManifests.swift
@@ -41,6 +41,7 @@ extension FamilyTests {
     static let __allTests__FamilyTests = [
         ("testFamilyAbandoned", testFamilyAbandoned),
         ("testFamilyBulkDestroy", testFamilyBulkDestroy),
+        ("testFamilyCreateMembers", testFamilyCreateMembers),
         ("testFamilyCreation", testFamilyCreation),
         ("testFamilyExchange", testFamilyExchange),
         ("testFamilyLateMember", testFamilyLateMember),


### PR DESCRIPTION
This PR adds a convenience method to families to easily add entities with components required by the family.

An example would be:

```swift
let nexus = Nexus()

let name = Name(name: "Some Component")
let position = Position(x: 12, y: 34)

let family = nexus.family(requires: Position.self, Name.self)
let newEntity = family.createMember(with: position, name)
```

The changes are purely additional.