### PR TITLE
Fix issue #21 Segmentation fault 11 Swift 5.3 / Xcode 12 beta

### DIFF
--- a/Sources/FirebladeECS/Family+Coding.swift
+++ b/Sources/FirebladeECS/Family+Coding.swift
@@ -18,7 +18,7 @@ extension FamilyMemberContainer: Encodable where R: FamilyEncoding {
     func encode(to encoder: Encoder) throws {
         let strategy = encoder.userInfo[.nexusCodingStrategy] as? CodingStrategy ?? DefaultCodingStrategy()
         var familyContainer = encoder.unkeyedContainer()
-        try R.encode(components: components, into: &familyContainer, using: strategy)
+        try R.encode(componentsArray: components, into: &familyContainer, using: strategy)
     }
 }
 

--- a/Sources/FirebladeECS/FamilyProtocols.swift
+++ b/Sources/FirebladeECS/FamilyProtocols.swift
@@ -23,13 +23,13 @@ public protocol FamilyRequirementsManaging {
 }
 
 public protocol FamilyEncoding: FamilyRequirementsManaging {
-    static func encode(components: [Components], into container: inout UnkeyedEncodingContainer, using strategy: CodingStrategy) throws
+    static func encode(componentsArray: [Components], into container: inout UnkeyedEncodingContainer, using strategy: CodingStrategy) throws
     static func encode(components: Components, into container: inout KeyedEncodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws
 }
 
 extension FamilyEncoding {
-    public static func encode(components: [Components], into container: inout UnkeyedEncodingContainer, using strategy: CodingStrategy) throws {
-        for comps in components {
+    public static func encode(componentsArray: [Components], into container: inout UnkeyedEncodingContainer, using strategy: CodingStrategy) throws {
+        for comps in componentsArray {
             var container = container.nestedContainer(keyedBy: DynamicCodingKey.self)
             try Self.encode(components: comps, into: &container, using: strategy)
         }


### PR DESCRIPTION
- This PR fixes issue https://github.com/fireblade-engine/ecs/issues/21 Segmentation fault 11 (FamilyProtocols.swift:25:8)
- This is still a Swift 5.3 compiler bug (see issue for details)
- Fix renames static function parameter and therefore resolves the extension conformance problems