### PR TITLE
Rename @_functionBuilder to @resultBuilder for Swift 5.4+

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Generate coverage report
         run: llvm-cov export -format="lcov" .build/debug/*PackageTests.xctest -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
       - name: Upload code coverage report
-        uses: codecov/codecov-action@master
+        uses: codecov/codecov-action@v1.5.2
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: coverage.lcov

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Generate coverage report
         run: xcrun llvm-cov export -format="lcov" .build/debug/*PackageTests.xctest/Contents/MacOS/*PackageTests -instr-profile .build/debug/codecov/default.profdata > coverage.lcov
       - name: Upload code coverage report
-        uses: codecov/codecov-action@master
+        uses: codecov/codecov-action@v1.5.2
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           file: coverage.lcov

--- a/Sources/FirebladeECS/FamilyMemberBuilder.swift
+++ b/Sources/FirebladeECS/FamilyMemberBuilder.swift
@@ -5,6 +5,10 @@
 //  Created by Christian Treffs on 07.08.20.
 //
 
+#if swift(<5.4)
 @_functionBuilder
-public enum FamilyMemberBuilderPreview<R> where R: FamilyRequirementsManaging { }
-public typealias FamilyMemberBuilder<R> = FamilyMemberBuilderPreview<R> where R: FamilyRequirementsManaging
+public enum FamilyMemberBuilder<R> where R: FamilyRequirementsManaging { }
+#else
+@resultBuilder
+public enum FamilyMemberBuilder<R> where R: FamilyRequirementsManaging { }
+#endif

--- a/Sources/FirebladeECS/Nexus+ComponentsBuilder.swift
+++ b/Sources/FirebladeECS/Nexus+ComponentsBuilder.swift
@@ -5,9 +5,13 @@
 //  Created by Christian Treffs on 30.07.20.
 //
 
+#if swift(<5.4)
 @_functionBuilder
-public enum ComponentsBuilderPreview { }
-public typealias ComponentsBuilder = ComponentsBuilderPreview
+public enum ComponentsBuilder { }
+#else
+@resultBuilder
+public enum ComponentsBuilder { }
+#endif
 
 extension ComponentsBuilder {
     public static func buildBlock(_ components: Component...) -> [Component] {


### PR DESCRIPTION
### Description

With Swift 5.4 `@_functionBuilder` is called `@resultBuilder`.
This PR accounts for that change.

### Documentation

https://github.com/apple/swift-evolution/blob/main/proposals/0289-result-builders.md#changes-from-the-first-revision

### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/fireblade-engine/ecs/blob/master/CONTRIBUTING.md)
- [x] I've followed the coding style of the rest of the project.
- [x] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.

