### PR TITLE
Value type components

### DIFF
--- a/Sources/FirebladeECS/Component.swift
+++ b/Sources/FirebladeECS/Component.swift
@@ -8,7 +8,7 @@
 /// **Component**
 ///
 /// A component represents the raw data for one aspect of an entity.
-public protocol Component: AnyObject {
+public protocol Component {
     /// Unique, immutable identifier of this component type.
     static var identifier: ComponentIdentifier { get }
 

--- a/Sources/FirebladeECS/Entity+Component.swift
+++ b/Sources/FirebladeECS/Entity+Component.swift
@@ -48,7 +48,7 @@ extension Entity {
                 self.remove(Comp.self)
                 return
             }
-            if self.get(component: componentType) === newComponent {
+            if self.get(component: componentType) != nil {
                 return
             }
             self.assign(newComponent)

--- a/Sources/FirebladeECS/FSM.swift
+++ b/Sources/FirebladeECS/FSM.swift
@@ -11,419 +11,419 @@ public protocol DefaultInitializable {
     init()
 }
 
-public typealias ComponentInitializable = Component & DefaultInitializable
-
-/// This is the Interface for component providers. Component providers are used to supply components
-/// for states within an EntityStateMachine. FirebladeECS includes three standard component providers,
-/// ComponentTypeProvider, ComponentInstanceProvider and ComponentSingletonProvider. Developers
-/// may wish to create more.
-public protocol ComponentProvider {
-    /// Returns an identifier that is used to determine whether two component providers will
-    /// return the equivalent components.
-
-    /// If an entity is changing state and the state it is leaving and the state is
-    /// entering have components of the same type, then the identifiers of the component
-    /// provders are compared. If the two identifiers are the same then the component
-    /// is not removed. If they are different, the component from the old state is removed
-    /// and a component for the new state is added.
-
-    /// - Returns: struct/class instance that conforms to Hashable protocol
-    var identifier: AnyHashable { get }
-
-    /// Used to request a component from the provider.
-    /// - Returns: A component for use in the state that the entity is entering
-    func getComponent() -> Component
-}
-
-// MARK: -
-
-/// This component provider always returns the same instance of the component. The instance
-/// is passed to the provider at initialisation.
-public final class ComponentInstanceProvider {
-    private var instance: Component
-
-    /// Initializer
-    /// - Parameter instance: The instance to return whenever a component is requested.
-    public init(instance: Component) {
-        self.instance = instance
-    }
-}
-
-extension ComponentInstanceProvider: ComponentProvider {
-    /// Used to compare this provider with others. Any provider that returns the same component
-    /// instance will be regarded as equivalent.
-    /// - Returns:ObjectIdentifier of instance
-    public var identifier: AnyHashable {
-        ObjectIdentifier(instance)
-    }
-
-    /// Used to request a component from this provider
-    /// - Returns: The instance
-    public func getComponent() -> Component {
-        instance
-    }
-}
-
-// MARK: -
-
-/// This component provider always returns a new instance of a component. An instance
-/// is created when requested and is of the type passed in to the initializer.
-public final class ComponentTypeProvider {
-    private var componentType: ComponentInitializable.Type
-
-    /// Used to compare this provider with others. Any ComponentTypeProvider that returns
-    /// the same type will be regarded as equivalent.
-    /// - Returns:ObjectIdentifier of the type of the instances created
-    public let identifier: AnyHashable
-
-    /// Initializer
-    /// - Parameter type: The type of the instances to be created
-    public init(type: ComponentInitializable.Type) {
-        componentType = type
-        identifier = ObjectIdentifier(componentType.self)
-    }
-}
-
-extension ComponentTypeProvider: ComponentProvider {
-    /// Used to request a component from this provider
-    /// - Returns: A new instance of the type provided in the initializer
-    public func getComponent() -> Component {
-        componentType.init()
-    }
-}
-
-// MARK: -
-
-/// This component provider always returns the same instance of the component. The instance
-/// is created when first required and is of the type passed in to the initializer.
-public final class ComponentSingletonProvider {
-    private lazy var instance: Component = {
-        componentType.init()
-    }()
-
-    private var componentType: ComponentInitializable.Type
-
-    /// Initializer
-    /// - Parameter type: The type of the single instance
-    public init(type: ComponentInitializable.Type) {
-        componentType = type
-    }
-}
-
-extension ComponentSingletonProvider: ComponentProvider {
-    /// Used to compare this provider with others. Any provider that returns the same single
-    /// instance will be regarded as equivalent.
-    /// - Returns: ObjectIdentifier of the single instance
-    public var identifier: AnyHashable {
-        ObjectIdentifier(instance)
-    }
-
-    /// Used to request a component from this provider
-    /// - Returns: The single instance
-    public func getComponent() -> Component {
-        instance
-    }
-}
-
-// MARK: -
-
-/// This component provider calls a function to get the component instance. The function must
-/// return a single component of the appropriate type.
-public final class DynamicComponentProvider<C: Component> {
-    /// Wrapper for closure to make it hashable via ObjectIdentifier
-    public final class Closure {
-        let provideComponent: () -> C
-
-        /// Initializer
-        /// - Parameter provideComponent: Swift closure returning component of the appropriate type
-        public init(provideComponent: @escaping () -> C) {
-            self.provideComponent = provideComponent
-        }
-    }
-
-    private let closure: Closure
-
-    /// Initializer
-    /// - Parameter closure: Instance of Closure class. A wrapper around closure that will
-    /// return the component instance when called.
-    public init(closure: Closure) {
-        self.closure = closure
-    }
-}
-
-extension DynamicComponentProvider: ComponentProvider {
-    /// Used to compare this provider with others. Any provider that uses the function or method
-    /// closure to provide the instance is regarded as equivalent.
-    /// - Returns: ObjectIdentifier of closure
-    public var identifier: AnyHashable {
-        ObjectIdentifier(closure)
-    }
-
-    /// Used to request a component from this provider
-    /// - Returns: The instance returned by calling the closure
-    public func getComponent() -> Component {
-        closure.provideComponent()
-    }
-}
-
-// MARK: -
-
-/// Represents a state for an EntityStateMachine. The state contains any number of ComponentProviders which
-/// are used to add components to the entity when this state is entered.
-public class EntityState {
-    internal var providers = [ComponentIdentifier: ComponentProvider]()
-
-    public init() {}
-
-    /// Add a new StateComponentMapping to this state. The mapping is a utility class that is used to
-    /// map a component type to the provider that provides the component.
-    /// - Parameter type: The type of component to be mapped
-    /// - Returns: The component mapping to use when setting the provider for the component
-    @discardableResult
-    public func addMapping(for type: ComponentInitializable.Type) -> StateComponentMapping {
-        StateComponentMapping(creatingState: self, type: type)
-    }
-
-    /// Get the ComponentProvider for a particular component type.
-    /// - Parameter type: The type of component to get the provider for
-    /// - Returns: The ComponentProvider
-    public func provider(for type: ComponentInitializable.Type) -> ComponentProvider? {
-        providers[type.identifier]
-    }
-
-    /// To determine whether this state has a provider for a specific component type.
-    /// - Parameter type: The type of component to look for a provider for
-    /// - Returns: true if there is a provider for the given type, false otherwise
-    public func hasProvider(for type: ComponentInitializable.Type) -> Bool {
-        providers[type.identifier] != nil
-    }
-}
-
-/// This extension provides ergonomic way to add component mapping and component
-/// provider at once
-extension EntityState {
-    /// Creates a mapping for the component type to a specific component instance.
-    /// ComponentInstanceProvider is used for the mapping.
-    /// - Parameter component: The component instance to use for the mapping
-    /// - Returns: This EntityState, so more modifications can be applied
-    @discardableResult
-    @inline(__always)
-    public func addInstance<C: ComponentInitializable>(_ component: C) -> Self {
-        addMapping(for: C.self).withInstance(component)
-        return self
-    }
-
-    /// Creates a mapping for the component type to new instances of the provided type.
-    /// A ComponentTypeProvider is used for the mapping.
-    /// - Parameter type: The type of components to be created by this mapping
-    /// - Returns: This EntityState, so more modifications can be applied
-    @inline(__always)
-    @discardableResult
-    public func addType(_ type: ComponentInitializable.Type) -> Self {
-        addMapping(for: type).withType(type)
-        return self
-    }
-
-    /// Creates a mapping for the component type to a single instance of the provided type.
-    /// The instance is not created until it is first requested.
-    /// A ComponentSingletonProvider is used for the mapping.
-    /// - Parameter type: The type of the single instance to be created.
-    /// - Returns: This EntityState, so more modifications can be applied
-    @inline(__always)
-    @discardableResult
-    public func addSingleton(_ type: ComponentInitializable.Type) -> Self {
-        addMapping(for: type).withSingleton(type)
-        return self
-    }
-
-    /// Creates a mapping for the component type to a method call.
-    /// A DynamicComponentProvider is used for the mapping.
-    /// - Parameter closure: The Closure instance to return the component instance
-    /// - Returns: This EntityState, so more modifications can be applied
-    @inline(__always)
-    @discardableResult
-    public func addMethod<C: ComponentInitializable>(closure: DynamicComponentProvider<C>.Closure) -> Self {
-        addMapping(for: C.self).withMethod(closure)
-        return self
-    }
-
-    /// Creates a mapping for the component type to any ComponentProvider.
-    /// - Parameter type: The type of component to be mapped
-    /// - Parameter provider: The component provider to use.
-    /// - Returns: This EntityState, so more modifications can be applied.
-    @inline(__always)
-    @discardableResult
-    public func addProvider<C: ComponentInitializable>(type: C.Type, provider: ComponentProvider) -> Self {
-        addMapping(for: type).withProvider(provider)
-        return self
-    }
-}
-
-// MARK: -
-
-/// Used by the EntityState class to create the mappings of components to providers via a fluent interface.
-public class StateComponentMapping {
-    private var componentType: ComponentInitializable.Type
-    private let creatingState: EntityState
-    private var provider: ComponentProvider
-
-    /// Used internally, the initializer creates a component mapping. The constructor
-    /// creates a ComponentTypeProvider as the default mapping, which will be replaced
-    /// by more specific mappings if other methods are called.
-    /// - Parameter creatingState: The EntityState that the mapping will belong to
-    /// - Parameter type: The component type for the mapping
-    internal init(creatingState: EntityState, type: ComponentInitializable.Type) {
-        self.creatingState = creatingState
-        componentType = type
-        provider = ComponentTypeProvider(type: type)
-        setProvider(provider)
-    }
-
-    /// Creates a mapping for the component type to a specific component instance. A
-    /// ComponentInstanceProvider is used for the mapping.
-    /// - Parameter component: The component instance to use for the mapping
-    /// - Returns: This ComponentMapping, so more modifications can be applied
-    @discardableResult
-    public func withInstance(_ component: Component) -> StateComponentMapping {
-        setProvider(ComponentInstanceProvider(instance: component))
-        return self
-    }
-
-    /// Creates a mapping for the component type to new instances of the provided type.
-    /// The type should be the same as or extend the type for this mapping. A ComponentTypeProvider
-    /// is used for the mapping.
-    /// - Parameter type: The type of components to be created by this mapping
-    /// - Returns: This ComponentMapping, so more modifications can be applied
-    @discardableResult
-    public func withType(_ type: ComponentInitializable.Type) -> Self {
-        setProvider(ComponentTypeProvider(type: type))
-        return self
-    }
-
-    /// Creates a mapping for the component type to a single instance of the provided type.
-    /// The instance is not created until it is first requested. The type should be the same
-    /// as or extend the type for this mapping. A ComponentSingletonProvider is used for
-    /// the mapping.
-    /// - Parameter type: The type of the single instance to be created. If omitted, the type of the
-    /// mapping is used.
-    /// - Returns: This ComponentMapping, so more modifications can be applied
-    @discardableResult
-    public func withSingleton(_ type: ComponentInitializable.Type?) -> Self {
-        setProvider(ComponentSingletonProvider(type: type ?? componentType))
-        return self
-    }
-
-    /// Creates a mapping for the component type to a method call. A
-    /// DynamicComponentProvider is used for the mapping.
-    /// - Parameter closure: The Closure instance to return the component instance
-    /// - Returns: This ComponentMapping, so more modifications can be applied
-    @discardableResult
-    public func withMethod<C: Component>(_ closure: DynamicComponentProvider<C>.Closure) -> Self {
-        setProvider(DynamicComponentProvider(closure: closure))
-        return self
-    }
-
-    /// Creates a mapping for the component type to any ComponentProvider.
-    /// - Parameter provider: The component provider to use.
-    /// - Returns: This ComponentMapping, so more modifications can be applied.
-    @discardableResult
-    public func withProvider(_ provider: ComponentProvider) -> Self {
-        setProvider(provider)
-        return self
-    }
-
-    /// Maps through to the addMapping method of the EntityState that this mapping belongs to
-    /// so that a fluent interface can be used when configuring entity states.
-    /// - Parameter type: The type of component to add a mapping to the state for
-    /// - Returns: The new ComponentMapping for that type
-    @discardableResult
-    public func add(_ type: ComponentInitializable.Type) -> StateComponentMapping {
-        creatingState.addMapping(for: type)
-    }
-
-    private func setProvider(_ provider: ComponentProvider) {
-        self.provider = provider
-        creatingState.providers[componentType.identifier] = provider
-    }
-}
-
-// MARK: -
-
-/// This is a state machine for an entity. The state machine manages a set of states,
-/// each of which has a set of component providers. When the state machine changes the state, it removes
-/// components associated with the previous state and adds components associated with the new state.
-/// - Parameter StateIdentifier: Generic hashable state name type
-public class EntityStateMachine<StateIdentifier: Hashable> {
-    private var states: [StateIdentifier: EntityState]
-
-    /// The current state of the state machine.
-    private var currentState: EntityState?
-
-    /// The entity whose state machine this is
-    public var entity: Entity
-
-    /// Initializer. Creates an EntityStateMachine.
-    public init(entity: Entity) {
-        self.entity = entity
-        states = [:]
-    }
-
-    /// Add a state to this state machine.
-    /// - Parameter name: The name of this state - used to identify it later in the changeState method call.
-    /// - Parameter state: The state.
-    /// - Returns: This state machine, so methods can be chained.
-    @discardableResult
-    public func addState(name: StateIdentifier, state: EntityState) -> Self {
-        states[name] = state
-        return self
-    }
-
-    /// Create a new state in this state machine.
-    /// - Parameter name: The name of the new state - used to identify it later in the changeState method call.
-    /// - Returns: The new EntityState object that is the state. This will need to be configured with
-    /// the appropriate component providers.
-    public func createState(name: StateIdentifier) -> EntityState {
-        let state = EntityState()
-        states[name] = state
-        return state
-    }
-
-    /// Change to a new state. The components from the old state will be removed and the components
-    /// for the new state will be added.
-    /// - Parameter name: The name of the state to change to.
-    public func changeState(name: StateIdentifier) {
-        guard let newState = states[name] else {
-            assertionFailure("Entity state '\(name)' doesn't exist")
-            return
-        }
-
-        if newState === currentState {
-            return
-        }
-
-        var toAdd: [ComponentIdentifier: ComponentProvider]
-
-        if let currentState = currentState {
-            toAdd = .init()
-            for (identifier, provider) in newState.providers {
-                toAdd[identifier] = provider
-            }
-
-            for (identifier, _) in currentState.providers {
-                if let other = toAdd[identifier], let current = currentState.providers[identifier],
-                   current.identifier == other.identifier {
-                    toAdd[identifier] = nil
-                } else {
-                    entity.remove(identifier)
-                }
-            }
-        } else {
-            toAdd = newState.providers
-        }
-
-        for (_, provider) in toAdd {
-            entity.assign(provider.getComponent())
-        }
-        currentState = newState
-    }
-}
+//public typealias ComponentInitializable = Component & DefaultInitializable
+//
+///// This is the Interface for component providers. Component providers are used to supply components
+///// for states within an EntityStateMachine. FirebladeECS includes three standard component providers,
+///// ComponentTypeProvider, ComponentInstanceProvider and ComponentSingletonProvider. Developers
+///// may wish to create more.
+//public protocol ComponentProvider {
+//    /// Returns an identifier that is used to determine whether two component providers will
+//    /// return the equivalent components.
+//
+//    /// If an entity is changing state and the state it is leaving and the state is
+//    /// entering have components of the same type, then the identifiers of the component
+//    /// provders are compared. If the two identifiers are the same then the component
+//    /// is not removed. If they are different, the component from the old state is removed
+//    /// and a component for the new state is added.
+//
+//    /// - Returns: struct/class instance that conforms to Hashable protocol
+//    var identifier: AnyHashable { get }
+//
+//    /// Used to request a component from the provider.
+//    /// - Returns: A component for use in the state that the entity is entering
+//    func getComponent() -> Component
+//}
+//
+//// MARK: -
+//
+///// This component provider always returns the same instance of the component. The instance
+///// is passed to the provider at initialisation.
+//public final class ComponentInstanceProvider {
+//    private var instance: Component
+//
+//    /// Initializer
+//    /// - Parameter instance: The instance to return whenever a component is requested.
+//    public init(instance: Component) {
+//        self.instance = instance
+//    }
+//}
+//
+//extension ComponentInstanceProvider: ComponentProvider {
+//    /// Used to compare this provider with others. Any provider that returns the same component
+//    /// instance will be regarded as equivalent.
+//    /// - Returns:ObjectIdentifier of instance
+//    public var identifier: AnyHashable {
+//        ObjectIdentifier(instance)
+//    }
+//
+//    /// Used to request a component from this provider
+//    /// - Returns: The instance
+//    public func getComponent() -> Component {
+//        instance
+//    }
+//}
+//
+//// MARK: -
+//
+///// This component provider always returns a new instance of a component. An instance
+///// is created when requested and is of the type passed in to the initializer.
+//public final class ComponentTypeProvider {
+//    private var componentType: ComponentInitializable.Type
+//
+//    /// Used to compare this provider with others. Any ComponentTypeProvider that returns
+//    /// the same type will be regarded as equivalent.
+//    /// - Returns:ObjectIdentifier of the type of the instances created
+//    public let identifier: AnyHashable
+//
+//    /// Initializer
+//    /// - Parameter type: The type of the instances to be created
+//    public init(type: ComponentInitializable.Type) {
+//        componentType = type
+//        identifier = ObjectIdentifier(componentType.self)
+//    }
+//}
+//
+//extension ComponentTypeProvider: ComponentProvider {
+//    /// Used to request a component from this provider
+//    /// - Returns: A new instance of the type provided in the initializer
+//    public func getComponent() -> Component {
+//        componentType.init()
+//    }
+//}
+//
+//// MARK: -
+//
+///// This component provider always returns the same instance of the component. The instance
+///// is created when first required and is of the type passed in to the initializer.
+//public final class ComponentSingletonProvider {
+//    private lazy var instance: Component = {
+//        componentType.init()
+//    }()
+//
+//    private var componentType: ComponentInitializable.Type
+//
+//    /// Initializer
+//    /// - Parameter type: The type of the single instance
+//    public init(type: ComponentInitializable.Type) {
+//        componentType = type
+//    }
+//}
+//
+//extension ComponentSingletonProvider: ComponentProvider {
+//    /// Used to compare this provider with others. Any provider that returns the same single
+//    /// instance will be regarded as equivalent.
+//    /// - Returns: ObjectIdentifier of the single instance
+//    public var identifier: AnyHashable {
+//        ObjectIdentifier(instance)
+//    }
+//
+//    /// Used to request a component from this provider
+//    /// - Returns: The single instance
+//    public func getComponent() -> Component {
+//        instance
+//    }
+//}
+//
+//// MARK: -
+//
+///// This component provider calls a function to get the component instance. The function must
+///// return a single component of the appropriate type.
+//public final class DynamicComponentProvider<C: Component> {
+//    /// Wrapper for closure to make it hashable via ObjectIdentifier
+//    public final class Closure {
+//        let provideComponent: () -> C
+//
+//        /// Initializer
+//        /// - Parameter provideComponent: Swift closure returning component of the appropriate type
+//        public init(provideComponent: @escaping () -> C) {
+//            self.provideComponent = provideComponent
+//        }
+//    }
+//
+//    private let closure: Closure
+//
+//    /// Initializer
+//    /// - Parameter closure: Instance of Closure class. A wrapper around closure that will
+//    /// return the component instance when called.
+//    public init(closure: Closure) {
+//        self.closure = closure
+//    }
+//}
+//
+//extension DynamicComponentProvider: ComponentProvider {
+//    /// Used to compare this provider with others. Any provider that uses the function or method
+//    /// closure to provide the instance is regarded as equivalent.
+//    /// - Returns: ObjectIdentifier of closure
+//    public var identifier: AnyHashable {
+//        ObjectIdentifier(closure)
+//    }
+//
+//    /// Used to request a component from this provider
+//    /// - Returns: The instance returned by calling the closure
+//    public func getComponent() -> Component {
+//        closure.provideComponent()
+//    }
+//}
+//
+//// MARK: -
+//
+///// Represents a state for an EntityStateMachine. The state contains any number of ComponentProviders which
+///// are used to add components to the entity when this state is entered.
+//public class EntityState {
+//    internal var providers = [ComponentIdentifier: ComponentProvider]()
+//
+//    public init() {}
+//
+//    /// Add a new StateComponentMapping to this state. The mapping is a utility class that is used to
+//    /// map a component type to the provider that provides the component.
+//    /// - Parameter type: The type of component to be mapped
+//    /// - Returns: The component mapping to use when setting the provider for the component
+//    @discardableResult
+//    public func addMapping(for type: ComponentInitializable.Type) -> StateComponentMapping {
+//        StateComponentMapping(creatingState: self, type: type)
+//    }
+//
+//    /// Get the ComponentProvider for a particular component type.
+//    /// - Parameter type: The type of component to get the provider for
+//    /// - Returns: The ComponentProvider
+//    public func provider(for type: ComponentInitializable.Type) -> ComponentProvider? {
+//        providers[type.identifier]
+//    }
+//
+//    /// To determine whether this state has a provider for a specific component type.
+//    /// - Parameter type: The type of component to look for a provider for
+//    /// - Returns: true if there is a provider for the given type, false otherwise
+//    public func hasProvider(for type: ComponentInitializable.Type) -> Bool {
+//        providers[type.identifier] != nil
+//    }
+//}
+//
+///// This extension provides ergonomic way to add component mapping and component
+///// provider at once
+//extension EntityState {
+//    /// Creates a mapping for the component type to a specific component instance.
+//    /// ComponentInstanceProvider is used for the mapping.
+//    /// - Parameter component: The component instance to use for the mapping
+//    /// - Returns: This EntityState, so more modifications can be applied
+//    @discardableResult
+//    @inline(__always)
+//    public func addInstance<C: ComponentInitializable>(_ component: C) -> Self {
+//        addMapping(for: C.self).withInstance(component)
+//        return self
+//    }
+//
+//    /// Creates a mapping for the component type to new instances of the provided type.
+//    /// A ComponentTypeProvider is used for the mapping.
+//    /// - Parameter type: The type of components to be created by this mapping
+//    /// - Returns: This EntityState, so more modifications can be applied
+//    @inline(__always)
+//    @discardableResult
+//    public func addType(_ type: ComponentInitializable.Type) -> Self {
+//        addMapping(for: type).withType(type)
+//        return self
+//    }
+//
+//    /// Creates a mapping for the component type to a single instance of the provided type.
+//    /// The instance is not created until it is first requested.
+//    /// A ComponentSingletonProvider is used for the mapping.
+//    /// - Parameter type: The type of the single instance to be created.
+//    /// - Returns: This EntityState, so more modifications can be applied
+//    @inline(__always)
+//    @discardableResult
+//    public func addSingleton(_ type: ComponentInitializable.Type) -> Self {
+//        addMapping(for: type).withSingleton(type)
+//        return self
+//    }
+//
+//    /// Creates a mapping for the component type to a method call.
+//    /// A DynamicComponentProvider is used for the mapping.
+//    /// - Parameter closure: The Closure instance to return the component instance
+//    /// - Returns: This EntityState, so more modifications can be applied
+//    @inline(__always)
+//    @discardableResult
+//    public func addMethod<C: ComponentInitializable>(closure: DynamicComponentProvider<C>.Closure) -> Self {
+//        addMapping(for: C.self).withMethod(closure)
+//        return self
+//    }
+//
+//    /// Creates a mapping for the component type to any ComponentProvider.
+//    /// - Parameter type: The type of component to be mapped
+//    /// - Parameter provider: The component provider to use.
+//    /// - Returns: This EntityState, so more modifications can be applied.
+//    @inline(__always)
+//    @discardableResult
+//    public func addProvider<C: ComponentInitializable>(type: C.Type, provider: ComponentProvider) -> Self {
+//        addMapping(for: type).withProvider(provider)
+//        return self
+//    }
+//}
+//
+//// MARK: -
+//
+///// Used by the EntityState class to create the mappings of components to providers via a fluent interface.
+//public class StateComponentMapping {
+//    private var componentType: ComponentInitializable.Type
+//    private let creatingState: EntityState
+//    private var provider: ComponentProvider
+//
+//    /// Used internally, the initializer creates a component mapping. The constructor
+//    /// creates a ComponentTypeProvider as the default mapping, which will be replaced
+//    /// by more specific mappings if other methods are called.
+//    /// - Parameter creatingState: The EntityState that the mapping will belong to
+//    /// - Parameter type: The component type for the mapping
+//    internal init(creatingState: EntityState, type: ComponentInitializable.Type) {
+//        self.creatingState = creatingState
+//        componentType = type
+//        provider = ComponentTypeProvider(type: type)
+//        setProvider(provider)
+//    }
+//
+//    /// Creates a mapping for the component type to a specific component instance. A
+//    /// ComponentInstanceProvider is used for the mapping.
+//    /// - Parameter component: The component instance to use for the mapping
+//    /// - Returns: This ComponentMapping, so more modifications can be applied
+//    @discardableResult
+//    public func withInstance(_ component: Component) -> StateComponentMapping {
+//        setProvider(ComponentInstanceProvider(instance: component))
+//        return self
+//    }
+//
+//    /// Creates a mapping for the component type to new instances of the provided type.
+//    /// The type should be the same as or extend the type for this mapping. A ComponentTypeProvider
+//    /// is used for the mapping.
+//    /// - Parameter type: The type of components to be created by this mapping
+//    /// - Returns: This ComponentMapping, so more modifications can be applied
+//    @discardableResult
+//    public func withType(_ type: ComponentInitializable.Type) -> Self {
+//        setProvider(ComponentTypeProvider(type: type))
+//        return self
+//    }
+//
+//    /// Creates a mapping for the component type to a single instance of the provided type.
+//    /// The instance is not created until it is first requested. The type should be the same
+//    /// as or extend the type for this mapping. A ComponentSingletonProvider is used for
+//    /// the mapping.
+//    /// - Parameter type: The type of the single instance to be created. If omitted, the type of the
+//    /// mapping is used.
+//    /// - Returns: This ComponentMapping, so more modifications can be applied
+//    @discardableResult
+//    public func withSingleton(_ type: ComponentInitializable.Type?) -> Self {
+//        setProvider(ComponentSingletonProvider(type: type ?? componentType))
+//        return self
+//    }
+//
+//    /// Creates a mapping for the component type to a method call. A
+//    /// DynamicComponentProvider is used for the mapping.
+//    /// - Parameter closure: The Closure instance to return the component instance
+//    /// - Returns: This ComponentMapping, so more modifications can be applied
+//    @discardableResult
+//    public func withMethod<C: Component>(_ closure: DynamicComponentProvider<C>.Closure) -> Self {
+//        setProvider(DynamicComponentProvider(closure: closure))
+//        return self
+//    }
+//
+//    /// Creates a mapping for the component type to any ComponentProvider.
+//    /// - Parameter provider: The component provider to use.
+//    /// - Returns: This ComponentMapping, so more modifications can be applied.
+//    @discardableResult
+//    public func withProvider(_ provider: ComponentProvider) -> Self {
+//        setProvider(provider)
+//        return self
+//    }
+//
+//    /// Maps through to the addMapping method of the EntityState that this mapping belongs to
+//    /// so that a fluent interface can be used when configuring entity states.
+//    /// - Parameter type: The type of component to add a mapping to the state for
+//    /// - Returns: The new ComponentMapping for that type
+//    @discardableResult
+//    public func add(_ type: ComponentInitializable.Type) -> StateComponentMapping {
+//        creatingState.addMapping(for: type)
+//    }
+//
+//    private func setProvider(_ provider: ComponentProvider) {
+//        self.provider = provider
+//        creatingState.providers[componentType.identifier] = provider
+//    }
+//}
+//
+//// MARK: -
+//
+///// This is a state machine for an entity. The state machine manages a set of states,
+///// each of which has a set of component providers. When the state machine changes the state, it removes
+///// components associated with the previous state and adds components associated with the new state.
+///// - Parameter StateIdentifier: Generic hashable state name type
+//public class EntityStateMachine<StateIdentifier: Hashable> {
+//    private var states: [StateIdentifier: EntityState]
+//
+//    /// The current state of the state machine.
+//    private var currentState: EntityState?
+//
+//    /// The entity whose state machine this is
+//    public var entity: Entity
+//
+//    /// Initializer. Creates an EntityStateMachine.
+//    public init(entity: Entity) {
+//        self.entity = entity
+//        states = [:]
+//    }
+//
+//    /// Add a state to this state machine.
+//    /// - Parameter name: The name of this state - used to identify it later in the changeState method call.
+//    /// - Parameter state: The state.
+//    /// - Returns: This state machine, so methods can be chained.
+//    @discardableResult
+//    public func addState(name: StateIdentifier, state: EntityState) -> Self {
+//        states[name] = state
+//        return self
+//    }
+//
+//    /// Create a new state in this state machine.
+//    /// - Parameter name: The name of the new state - used to identify it later in the changeState method call.
+//    /// - Returns: The new EntityState object that is the state. This will need to be configured with
+//    /// the appropriate component providers.
+//    public func createState(name: StateIdentifier) -> EntityState {
+//        let state = EntityState()
+//        states[name] = state
+//        return state
+//    }
+//
+//    /// Change to a new state. The components from the old state will be removed and the components
+//    /// for the new state will be added.
+//    /// - Parameter name: The name of the state to change to.
+//    public func changeState(name: StateIdentifier) {
+//        guard let newState = states[name] else {
+//            assertionFailure("Entity state '\(name)' doesn't exist")
+//            return
+//        }
+//
+//        if newState === currentState {
+//            return
+//        }
+//
+//        var toAdd: [ComponentIdentifier: ComponentProvider]
+//
+//        if let currentState = currentState {
+//            toAdd = .init()
+//            for (identifier, provider) in newState.providers {
+//                toAdd[identifier] = provider
+//            }
+//
+//            for (identifier, _) in currentState.providers {
+//                if let other = toAdd[identifier], let current = currentState.providers[identifier],
+//                   current.identifier == other.identifier {
+//                    toAdd[identifier] = nil
+//                } else {
+//                    entity.remove(identifier)
+//                }
+//            }
+//        } else {
+//            toAdd = newState.providers
+//        }
+//
+//        for (_, provider) in toAdd {
+//            entity.assign(provider.getComponent())
+//        }
+//        currentState = newState
+//    }
+//}

--- a/Sources/FirebladeECS/Generated/Family.generated.swift
+++ b/Sources/FirebladeECS/Generated/Family.generated.swift
@@ -1,6 +1,5 @@
-// Generated using Sourcery 1.0.0 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 1.6.1 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-
 // swiftlint:disable file_length
 // swiftlint:disable function_parameter_count
 // swiftlint:disable large_tuple
@@ -28,7 +27,7 @@ public struct Requires1<Comp1>: FamilyRequirementsManaging where Comp1: Componen
     }
 
     public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1) {
-        let entity = Entity(nexus: nexus, id: entityId)
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
         let comp1: Comp1 = nexus.get(unsafe: entityId)
         return (entity, comp1)
     }
@@ -40,9 +39,9 @@ public struct Requires1<Comp1>: FamilyRequirementsManaging where Comp1: Componen
 
 extension Requires1: RequiringComponents1 { }
 
-extension FamilyMemberBuilder where R: RequiringComponents1 {
+extension FamilyMemberBuilder where R: RequiringComponents1  {
     public static func buildBlock(_ comp1: R.Comp1) -> (R.Components) {
-        (comp1)
+        return (comp1)
     }
 }
 
@@ -122,7 +121,7 @@ public struct Requires2<Comp1, Comp2>: FamilyRequirementsManaging where Comp1: C
     }
 
     public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2) {
-        let entity = Entity(nexus: nexus, id: entityId)
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
         let comp1: Comp1 = nexus.get(unsafe: entityId)
         let comp2: Comp2 = nexus.get(unsafe: entityId)
         return (entity, comp1, comp2)
@@ -135,9 +134,9 @@ public struct Requires2<Comp1, Comp2>: FamilyRequirementsManaging where Comp1: C
 
 extension Requires2: RequiringComponents2 { }
 
-extension FamilyMemberBuilder where R: RequiringComponents2 {
+extension FamilyMemberBuilder where R: RequiringComponents2  {
     public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2) -> (R.Components) {
-        (comp1, comp2)
+        return (comp1, comp2)
     }
 }
 
@@ -222,7 +221,7 @@ public struct Requires3<Comp1, Comp2, Comp3>: FamilyRequirementsManaging where C
     }
 
     public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3) {
-        let entity = Entity(nexus: nexus, id: entityId)
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
         let comp1: Comp1 = nexus.get(unsafe: entityId)
         let comp2: Comp2 = nexus.get(unsafe: entityId)
         let comp3: Comp3 = nexus.get(unsafe: entityId)
@@ -236,9 +235,9 @@ public struct Requires3<Comp1, Comp2, Comp3>: FamilyRequirementsManaging where C
 
 extension Requires3: RequiringComponents3 { }
 
-extension FamilyMemberBuilder where R: RequiringComponents3 {
+extension FamilyMemberBuilder where R: RequiringComponents3  {
     public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3) -> (R.Components) {
-        (comp1, comp2, comp3)
+        return (comp1, comp2, comp3)
     }
 }
 
@@ -328,7 +327,7 @@ public struct Requires4<Comp1, Comp2, Comp3, Comp4>: FamilyRequirementsManaging 
     }
 
     public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4) {
-        let entity = Entity(nexus: nexus, id: entityId)
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
         let comp1: Comp1 = nexus.get(unsafe: entityId)
         let comp2: Comp2 = nexus.get(unsafe: entityId)
         let comp3: Comp3 = nexus.get(unsafe: entityId)
@@ -343,9 +342,9 @@ public struct Requires4<Comp1, Comp2, Comp3, Comp4>: FamilyRequirementsManaging 
 
 extension Requires4: RequiringComponents4 { }
 
-extension FamilyMemberBuilder where R: RequiringComponents4 {
+extension FamilyMemberBuilder where R: RequiringComponents4  {
     public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4) -> (R.Components) {
-        (comp1, comp2, comp3, comp4)
+        return (comp1, comp2, comp3, comp4)
     }
 }
 
@@ -440,7 +439,7 @@ public struct Requires5<Comp1, Comp2, Comp3, Comp4, Comp5>: FamilyRequirementsMa
     }
 
     public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5) {
-        let entity = Entity(nexus: nexus, id: entityId)
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
         let comp1: Comp1 = nexus.get(unsafe: entityId)
         let comp2: Comp2 = nexus.get(unsafe: entityId)
         let comp3: Comp3 = nexus.get(unsafe: entityId)
@@ -456,9 +455,9 @@ public struct Requires5<Comp1, Comp2, Comp3, Comp4, Comp5>: FamilyRequirementsMa
 
 extension Requires5: RequiringComponents5 { }
 
-extension FamilyMemberBuilder where R: RequiringComponents5 {
+extension FamilyMemberBuilder where R: RequiringComponents5  {
     public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5) -> (R.Components) {
-        (comp1, comp2, comp3, comp4, comp5)
+        return (comp1, comp2, comp3, comp4, comp5)
     }
 }
 
@@ -558,7 +557,7 @@ public struct Requires6<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6>: FamilyRequire
     }
 
     public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6) {
-        let entity = Entity(nexus: nexus, id: entityId)
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
         let comp1: Comp1 = nexus.get(unsafe: entityId)
         let comp2: Comp2 = nexus.get(unsafe: entityId)
         let comp3: Comp3 = nexus.get(unsafe: entityId)
@@ -575,9 +574,9 @@ public struct Requires6<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6>: FamilyRequire
 
 extension Requires6: RequiringComponents6 { }
 
-extension FamilyMemberBuilder where R: RequiringComponents6 {
+extension FamilyMemberBuilder where R: RequiringComponents6  {
     public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5, _ comp6: R.Comp6) -> (R.Components) {
-        (comp1, comp2, comp3, comp4, comp5, comp6)
+        return (comp1, comp2, comp3, comp4, comp5, comp6)
     }
 }
 
@@ -682,7 +681,7 @@ public struct Requires7<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7>: Family
     }
 
     public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7) {
-        let entity = Entity(nexus: nexus, id: entityId)
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
         let comp1: Comp1 = nexus.get(unsafe: entityId)
         let comp2: Comp2 = nexus.get(unsafe: entityId)
         let comp3: Comp3 = nexus.get(unsafe: entityId)
@@ -700,9 +699,9 @@ public struct Requires7<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7>: Family
 
 extension Requires7: RequiringComponents7 { }
 
-extension FamilyMemberBuilder where R: RequiringComponents7 {
+extension FamilyMemberBuilder where R: RequiringComponents7  {
     public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5, _ comp6: R.Comp6, _ comp7: R.Comp7) -> (R.Components) {
-        (comp1, comp2, comp3, comp4, comp5, comp6, comp7)
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7)
     }
 }
 
@@ -812,7 +811,7 @@ public struct Requires8<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8>:
     }
 
     public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8) {
-        let entity = Entity(nexus: nexus, id: entityId)
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
         let comp1: Comp1 = nexus.get(unsafe: entityId)
         let comp2: Comp2 = nexus.get(unsafe: entityId)
         let comp3: Comp3 = nexus.get(unsafe: entityId)
@@ -831,9 +830,9 @@ public struct Requires8<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8>:
 
 extension Requires8: RequiringComponents8 { }
 
-extension FamilyMemberBuilder where R: RequiringComponents8 {
+extension FamilyMemberBuilder where R: RequiringComponents8  {
     public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5, _ comp6: R.Comp6, _ comp7: R.Comp7, _ comp8: R.Comp8) -> (R.Components) {
-        (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8)
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8)
     }
 }
 
@@ -906,6 +905,1294 @@ extension Nexus {
         Family8<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8>(
             nexus: self,
             requiresAll: (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8),
+            excludesAll: excludedComponents
+        )
+    }
+}
+
+// MARK: - Family 9
+
+public typealias Family9<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9> = Family<Requires9<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9>> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component
+
+public protocol RequiringComponents9: FamilyRequirementsManaging where Components == (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9) {
+    associatedtype Comp1: Component
+    associatedtype Comp2: Component
+    associatedtype Comp3: Component
+    associatedtype Comp4: Component
+    associatedtype Comp5: Component
+    associatedtype Comp6: Component
+    associatedtype Comp7: Component
+    associatedtype Comp8: Component
+    associatedtype Comp9: Component
+}
+
+public struct Requires9<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9>: FamilyRequirementsManaging where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component {
+    public let componentTypes: [Component.Type]
+
+    public init(_ components: (Comp1.Type, Comp2.Type, Comp3.Type, Comp4.Type, Comp5.Type, Comp6.Type, Comp7.Type, Comp8.Type, Comp9.Type)) {
+        componentTypes = [Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self]
+    }
+
+    public static func components(nexus: Nexus, entityId: EntityIdentifier) -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9) {
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9)
+    }
+
+    public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9) {
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        return (entity, comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9)
+    }
+
+    public static func createMember(nexus: Nexus, components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9)) -> Entity {
+        nexus.createEntity(with: components.0, components.1, components.2, components.3, components.4, components.5, components.6, components.7, components.8)
+    }
+}
+
+extension Requires9: RequiringComponents9 { }
+
+extension FamilyMemberBuilder where R: RequiringComponents9  {
+    public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5, _ comp6: R.Comp6, _ comp7: R.Comp7, _ comp8: R.Comp8, _ comp9: R.Comp9) -> (R.Components) {
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9)
+    }
+}
+
+extension Requires9: FamilyEncoding where Comp1: Encodable, Comp2: Encodable, Comp3: Encodable, Comp4: Encodable, Comp5: Encodable, Comp6: Encodable, Comp7: Encodable, Comp8: Encodable, Comp9: Encodable {
+    public static func encode(components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9), into container: inout KeyedEncodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws {
+        try container.encode(components.0, forKey: strategy.codingKey(for: Comp1.self))
+        try container.encode(components.1, forKey: strategy.codingKey(for: Comp2.self))
+        try container.encode(components.2, forKey: strategy.codingKey(for: Comp3.self))
+        try container.encode(components.3, forKey: strategy.codingKey(for: Comp4.self))
+        try container.encode(components.4, forKey: strategy.codingKey(for: Comp5.self))
+        try container.encode(components.5, forKey: strategy.codingKey(for: Comp6.self))
+        try container.encode(components.6, forKey: strategy.codingKey(for: Comp7.self))
+        try container.encode(components.7, forKey: strategy.codingKey(for: Comp8.self))
+        try container.encode(components.8, forKey: strategy.codingKey(for: Comp9.self))
+    }
+}
+
+extension Requires9: FamilyDecoding where Comp1: Decodable, Comp2: Decodable, Comp3: Decodable, Comp4: Decodable, Comp5: Decodable, Comp6: Decodable, Comp7: Decodable, Comp8: Decodable, Comp9: Decodable {
+    public static func decode(componentsIn container: KeyedDecodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9) {
+        let comp1 = try container.decode(Comp1.self, forKey: strategy.codingKey(for: Comp1.self))
+        let comp2 = try container.decode(Comp2.self, forKey: strategy.codingKey(for: Comp2.self))
+        let comp3 = try container.decode(Comp3.self, forKey: strategy.codingKey(for: Comp3.self))
+        let comp4 = try container.decode(Comp4.self, forKey: strategy.codingKey(for: Comp4.self))
+        let comp5 = try container.decode(Comp5.self, forKey: strategy.codingKey(for: Comp5.self))
+        let comp6 = try container.decode(Comp6.self, forKey: strategy.codingKey(for: Comp6.self))
+        let comp7 = try container.decode(Comp7.self, forKey: strategy.codingKey(for: Comp7.self))
+        let comp8 = try container.decode(Comp8.self, forKey: strategy.codingKey(for: Comp8.self))
+        let comp9 = try container.decode(Comp9.self, forKey: strategy.codingKey(for: Comp9.self))
+        return Components(comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9)
+    }
+}
+
+extension Nexus {
+    /// Create a family of entities (aka members) having 9 required components.
+    ///
+    /// A family is a collection of entities with uniform component types per entity.
+    /// Entities that are be part of this family will have at least the 9 required components,
+    /// but may have more components assigned.
+    ///
+    /// A family is just a view on (component) data, creating them is cheap.
+    /// Use them to iterate efficiently over entities with the same components assigned.
+    /// Families with the same requirements provide a view on the same collection of entities (aka members).
+    /// A family conforms to the `LazySequenceProtocol` and therefore can be accessed like any other (lazy) sequence.
+    ///
+    /// **General usage**
+    /// ```swift
+    /// let family = nexus.family(requiresAll: Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self)
+    /// // iterate each entity's components
+    /// family.forEach { (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9) in
+    ///   ...
+    /// }
+    /// ```
+    /// **Caveats**
+    /// - Component types must be unique per family
+    /// - Component type order is arbitrary
+    ///
+    /// - Parameters:
+    ///   - comp1: Component type 1 required by members of this family.
+    ///   - comp2: Component type 2 required by members of this family.
+    ///   - comp3: Component type 3 required by members of this family.
+    ///   - comp4: Component type 4 required by members of this family.
+    ///   - comp5: Component type 5 required by members of this family.
+    ///   - comp6: Component type 6 required by members of this family.
+    ///   - comp7: Component type 7 required by members of this family.
+    ///   - comp8: Component type 8 required by members of this family.
+    ///   - comp9: Component type 9 required by members of this family.
+    ///   - excludedComponents: All component types that must not be assigned to an entity in this family.
+    /// - Returns: The family of entities having 9 required components each.
+    public func family<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9>(
+        requiresAll comp1: Comp1.Type, _ comp2: Comp2.Type, _ comp3: Comp3.Type, _ comp4: Comp4.Type, _ comp5: Comp5.Type, _ comp6: Comp6.Type, _ comp7: Comp7.Type, _ comp8: Comp8.Type, _ comp9: Comp9.Type,
+        excludesAll excludedComponents: Component.Type...
+    ) -> Family9<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component {
+        Family9<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9>(
+            nexus: self,
+            requiresAll: (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9),
+            excludesAll: excludedComponents
+        )
+    }
+}
+
+// MARK: - Family 10
+
+public typealias Family10<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10> = Family<Requires10<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10>> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component
+
+public protocol RequiringComponents10: FamilyRequirementsManaging where Components == (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10) {
+    associatedtype Comp1: Component
+    associatedtype Comp2: Component
+    associatedtype Comp3: Component
+    associatedtype Comp4: Component
+    associatedtype Comp5: Component
+    associatedtype Comp6: Component
+    associatedtype Comp7: Component
+    associatedtype Comp8: Component
+    associatedtype Comp9: Component
+    associatedtype Comp10: Component
+}
+
+public struct Requires10<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10>: FamilyRequirementsManaging where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component {
+    public let componentTypes: [Component.Type]
+
+    public init(_ components: (Comp1.Type, Comp2.Type, Comp3.Type, Comp4.Type, Comp5.Type, Comp6.Type, Comp7.Type, Comp8.Type, Comp9.Type, Comp10.Type)) {
+        componentTypes = [Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self]
+    }
+
+    public static func components(nexus: Nexus, entityId: EntityIdentifier) -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10) {
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10)
+    }
+
+    public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10) {
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        return (entity, comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10)
+    }
+
+    public static func createMember(nexus: Nexus, components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10)) -> Entity {
+        nexus.createEntity(with: components.0, components.1, components.2, components.3, components.4, components.5, components.6, components.7, components.8, components.9)
+    }
+}
+
+extension Requires10: RequiringComponents10 { }
+
+extension FamilyMemberBuilder where R: RequiringComponents10  {
+    public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5, _ comp6: R.Comp6, _ comp7: R.Comp7, _ comp8: R.Comp8, _ comp9: R.Comp9, _ comp10: R.Comp10) -> (R.Components) {
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10)
+    }
+}
+
+extension Requires10: FamilyEncoding where Comp1: Encodable, Comp2: Encodable, Comp3: Encodable, Comp4: Encodable, Comp5: Encodable, Comp6: Encodable, Comp7: Encodable, Comp8: Encodable, Comp9: Encodable, Comp10: Encodable {
+    public static func encode(components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10), into container: inout KeyedEncodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws {
+        try container.encode(components.0, forKey: strategy.codingKey(for: Comp1.self))
+        try container.encode(components.1, forKey: strategy.codingKey(for: Comp2.self))
+        try container.encode(components.2, forKey: strategy.codingKey(for: Comp3.self))
+        try container.encode(components.3, forKey: strategy.codingKey(for: Comp4.self))
+        try container.encode(components.4, forKey: strategy.codingKey(for: Comp5.self))
+        try container.encode(components.5, forKey: strategy.codingKey(for: Comp6.self))
+        try container.encode(components.6, forKey: strategy.codingKey(for: Comp7.self))
+        try container.encode(components.7, forKey: strategy.codingKey(for: Comp8.self))
+        try container.encode(components.8, forKey: strategy.codingKey(for: Comp9.self))
+        try container.encode(components.9, forKey: strategy.codingKey(for: Comp10.self))
+    }
+}
+
+extension Requires10: FamilyDecoding where Comp1: Decodable, Comp2: Decodable, Comp3: Decodable, Comp4: Decodable, Comp5: Decodable, Comp6: Decodable, Comp7: Decodable, Comp8: Decodable, Comp9: Decodable, Comp10: Decodable {
+    public static func decode(componentsIn container: KeyedDecodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10) {
+        let comp1 = try container.decode(Comp1.self, forKey: strategy.codingKey(for: Comp1.self))
+        let comp2 = try container.decode(Comp2.self, forKey: strategy.codingKey(for: Comp2.self))
+        let comp3 = try container.decode(Comp3.self, forKey: strategy.codingKey(for: Comp3.self))
+        let comp4 = try container.decode(Comp4.self, forKey: strategy.codingKey(for: Comp4.self))
+        let comp5 = try container.decode(Comp5.self, forKey: strategy.codingKey(for: Comp5.self))
+        let comp6 = try container.decode(Comp6.self, forKey: strategy.codingKey(for: Comp6.self))
+        let comp7 = try container.decode(Comp7.self, forKey: strategy.codingKey(for: Comp7.self))
+        let comp8 = try container.decode(Comp8.self, forKey: strategy.codingKey(for: Comp8.self))
+        let comp9 = try container.decode(Comp9.self, forKey: strategy.codingKey(for: Comp9.self))
+        let comp10 = try container.decode(Comp10.self, forKey: strategy.codingKey(for: Comp10.self))
+        return Components(comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10)
+    }
+}
+
+extension Nexus {
+    /// Create a family of entities (aka members) having 10 required components.
+    ///
+    /// A family is a collection of entities with uniform component types per entity.
+    /// Entities that are be part of this family will have at least the 10 required components,
+    /// but may have more components assigned.
+    ///
+    /// A family is just a view on (component) data, creating them is cheap.
+    /// Use them to iterate efficiently over entities with the same components assigned.
+    /// Families with the same requirements provide a view on the same collection of entities (aka members).
+    /// A family conforms to the `LazySequenceProtocol` and therefore can be accessed like any other (lazy) sequence.
+    ///
+    /// **General usage**
+    /// ```swift
+    /// let family = nexus.family(requiresAll: Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self)
+    /// // iterate each entity's components
+    /// family.forEach { (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10) in
+    ///   ...
+    /// }
+    /// ```
+    /// **Caveats**
+    /// - Component types must be unique per family
+    /// - Component type order is arbitrary
+    ///
+    /// - Parameters:
+    ///   - comp1: Component type 1 required by members of this family.
+    ///   - comp2: Component type 2 required by members of this family.
+    ///   - comp3: Component type 3 required by members of this family.
+    ///   - comp4: Component type 4 required by members of this family.
+    ///   - comp5: Component type 5 required by members of this family.
+    ///   - comp6: Component type 6 required by members of this family.
+    ///   - comp7: Component type 7 required by members of this family.
+    ///   - comp8: Component type 8 required by members of this family.
+    ///   - comp9: Component type 9 required by members of this family.
+    ///   - comp10: Component type 10 required by members of this family.
+    ///   - excludedComponents: All component types that must not be assigned to an entity in this family.
+    /// - Returns: The family of entities having 10 required components each.
+    public func family<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10>(
+        requiresAll comp1: Comp1.Type, _ comp2: Comp2.Type, _ comp3: Comp3.Type, _ comp4: Comp4.Type, _ comp5: Comp5.Type, _ comp6: Comp6.Type, _ comp7: Comp7.Type, _ comp8: Comp8.Type, _ comp9: Comp9.Type, _ comp10: Comp10.Type,
+        excludesAll excludedComponents: Component.Type...
+    ) -> Family10<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component {
+        Family10<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10>(
+            nexus: self,
+            requiresAll: (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10),
+            excludesAll: excludedComponents
+        )
+    }
+}
+
+// MARK: - Family 11
+
+public typealias Family11<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11> = Family<Requires11<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11>> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component
+
+public protocol RequiringComponents11: FamilyRequirementsManaging where Components == (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11) {
+    associatedtype Comp1: Component
+    associatedtype Comp2: Component
+    associatedtype Comp3: Component
+    associatedtype Comp4: Component
+    associatedtype Comp5: Component
+    associatedtype Comp6: Component
+    associatedtype Comp7: Component
+    associatedtype Comp8: Component
+    associatedtype Comp9: Component
+    associatedtype Comp10: Component
+    associatedtype Comp11: Component
+}
+
+public struct Requires11<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11>: FamilyRequirementsManaging where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component {
+    public let componentTypes: [Component.Type]
+
+    public init(_ components: (Comp1.Type, Comp2.Type, Comp3.Type, Comp4.Type, Comp5.Type, Comp6.Type, Comp7.Type, Comp8.Type, Comp9.Type, Comp10.Type, Comp11.Type)) {
+        componentTypes = [Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self]
+    }
+
+    public static func components(nexus: Nexus, entityId: EntityIdentifier) -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11) {
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11)
+    }
+
+    public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11) {
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        return (entity, comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11)
+    }
+
+    public static func createMember(nexus: Nexus, components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11)) -> Entity {
+        nexus.createEntity(with: components.0, components.1, components.2, components.3, components.4, components.5, components.6, components.7, components.8, components.9, components.10)
+    }
+}
+
+extension Requires11: RequiringComponents11 { }
+
+extension FamilyMemberBuilder where R: RequiringComponents11  {
+    public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5, _ comp6: R.Comp6, _ comp7: R.Comp7, _ comp8: R.Comp8, _ comp9: R.Comp9, _ comp10: R.Comp10, _ comp11: R.Comp11) -> (R.Components) {
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11)
+    }
+}
+
+extension Requires11: FamilyEncoding where Comp1: Encodable, Comp2: Encodable, Comp3: Encodable, Comp4: Encodable, Comp5: Encodable, Comp6: Encodable, Comp7: Encodable, Comp8: Encodable, Comp9: Encodable, Comp10: Encodable, Comp11: Encodable {
+    public static func encode(components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11), into container: inout KeyedEncodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws {
+        try container.encode(components.0, forKey: strategy.codingKey(for: Comp1.self))
+        try container.encode(components.1, forKey: strategy.codingKey(for: Comp2.self))
+        try container.encode(components.2, forKey: strategy.codingKey(for: Comp3.self))
+        try container.encode(components.3, forKey: strategy.codingKey(for: Comp4.self))
+        try container.encode(components.4, forKey: strategy.codingKey(for: Comp5.self))
+        try container.encode(components.5, forKey: strategy.codingKey(for: Comp6.self))
+        try container.encode(components.6, forKey: strategy.codingKey(for: Comp7.self))
+        try container.encode(components.7, forKey: strategy.codingKey(for: Comp8.self))
+        try container.encode(components.8, forKey: strategy.codingKey(for: Comp9.self))
+        try container.encode(components.9, forKey: strategy.codingKey(for: Comp10.self))
+        try container.encode(components.10, forKey: strategy.codingKey(for: Comp11.self))
+    }
+}
+
+extension Requires11: FamilyDecoding where Comp1: Decodable, Comp2: Decodable, Comp3: Decodable, Comp4: Decodable, Comp5: Decodable, Comp6: Decodable, Comp7: Decodable, Comp8: Decodable, Comp9: Decodable, Comp10: Decodable, Comp11: Decodable {
+    public static func decode(componentsIn container: KeyedDecodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11) {
+        let comp1 = try container.decode(Comp1.self, forKey: strategy.codingKey(for: Comp1.self))
+        let comp2 = try container.decode(Comp2.self, forKey: strategy.codingKey(for: Comp2.self))
+        let comp3 = try container.decode(Comp3.self, forKey: strategy.codingKey(for: Comp3.self))
+        let comp4 = try container.decode(Comp4.self, forKey: strategy.codingKey(for: Comp4.self))
+        let comp5 = try container.decode(Comp5.self, forKey: strategy.codingKey(for: Comp5.self))
+        let comp6 = try container.decode(Comp6.self, forKey: strategy.codingKey(for: Comp6.self))
+        let comp7 = try container.decode(Comp7.self, forKey: strategy.codingKey(for: Comp7.self))
+        let comp8 = try container.decode(Comp8.self, forKey: strategy.codingKey(for: Comp8.self))
+        let comp9 = try container.decode(Comp9.self, forKey: strategy.codingKey(for: Comp9.self))
+        let comp10 = try container.decode(Comp10.self, forKey: strategy.codingKey(for: Comp10.self))
+        let comp11 = try container.decode(Comp11.self, forKey: strategy.codingKey(for: Comp11.self))
+        return Components(comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11)
+    }
+}
+
+extension Nexus {
+    /// Create a family of entities (aka members) having 11 required components.
+    ///
+    /// A family is a collection of entities with uniform component types per entity.
+    /// Entities that are be part of this family will have at least the 11 required components,
+    /// but may have more components assigned.
+    ///
+    /// A family is just a view on (component) data, creating them is cheap.
+    /// Use them to iterate efficiently over entities with the same components assigned.
+    /// Families with the same requirements provide a view on the same collection of entities (aka members).
+    /// A family conforms to the `LazySequenceProtocol` and therefore can be accessed like any other (lazy) sequence.
+    ///
+    /// **General usage**
+    /// ```swift
+    /// let family = nexus.family(requiresAll: Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self)
+    /// // iterate each entity's components
+    /// family.forEach { (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11) in
+    ///   ...
+    /// }
+    /// ```
+    /// **Caveats**
+    /// - Component types must be unique per family
+    /// - Component type order is arbitrary
+    ///
+    /// - Parameters:
+    ///   - comp1: Component type 1 required by members of this family.
+    ///   - comp2: Component type 2 required by members of this family.
+    ///   - comp3: Component type 3 required by members of this family.
+    ///   - comp4: Component type 4 required by members of this family.
+    ///   - comp5: Component type 5 required by members of this family.
+    ///   - comp6: Component type 6 required by members of this family.
+    ///   - comp7: Component type 7 required by members of this family.
+    ///   - comp8: Component type 8 required by members of this family.
+    ///   - comp9: Component type 9 required by members of this family.
+    ///   - comp10: Component type 10 required by members of this family.
+    ///   - comp11: Component type 11 required by members of this family.
+    ///   - excludedComponents: All component types that must not be assigned to an entity in this family.
+    /// - Returns: The family of entities having 11 required components each.
+    public func family<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11>(
+        requiresAll comp1: Comp1.Type, _ comp2: Comp2.Type, _ comp3: Comp3.Type, _ comp4: Comp4.Type, _ comp5: Comp5.Type, _ comp6: Comp6.Type, _ comp7: Comp7.Type, _ comp8: Comp8.Type, _ comp9: Comp9.Type, _ comp10: Comp10.Type, _ comp11: Comp11.Type,
+        excludesAll excludedComponents: Component.Type...
+    ) -> Family11<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component {
+        Family11<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11>(
+            nexus: self,
+            requiresAll: (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11),
+            excludesAll: excludedComponents
+        )
+    }
+}
+
+// MARK: - Family 12
+
+public typealias Family12<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12> = Family<Requires12<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12>> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component
+
+public protocol RequiringComponents12: FamilyRequirementsManaging where Components == (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12) {
+    associatedtype Comp1: Component
+    associatedtype Comp2: Component
+    associatedtype Comp3: Component
+    associatedtype Comp4: Component
+    associatedtype Comp5: Component
+    associatedtype Comp6: Component
+    associatedtype Comp7: Component
+    associatedtype Comp8: Component
+    associatedtype Comp9: Component
+    associatedtype Comp10: Component
+    associatedtype Comp11: Component
+    associatedtype Comp12: Component
+}
+
+public struct Requires12<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12>: FamilyRequirementsManaging where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component {
+    public let componentTypes: [Component.Type]
+
+    public init(_ components: (Comp1.Type, Comp2.Type, Comp3.Type, Comp4.Type, Comp5.Type, Comp6.Type, Comp7.Type, Comp8.Type, Comp9.Type, Comp10.Type, Comp11.Type, Comp12.Type)) {
+        componentTypes = [Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self, Comp12.self]
+    }
+
+    public static func components(nexus: Nexus, entityId: EntityIdentifier) -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12) {
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        let comp12: Comp12 = nexus.get(unsafe: entityId)
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12)
+    }
+
+    public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12) {
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        let comp12: Comp12 = nexus.get(unsafe: entityId)
+        return (entity, comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12)
+    }
+
+    public static func createMember(nexus: Nexus, components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12)) -> Entity {
+        nexus.createEntity(with: components.0, components.1, components.2, components.3, components.4, components.5, components.6, components.7, components.8, components.9, components.10, components.11)
+    }
+}
+
+extension Requires12: RequiringComponents12 { }
+
+extension FamilyMemberBuilder where R: RequiringComponents12  {
+    public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5, _ comp6: R.Comp6, _ comp7: R.Comp7, _ comp8: R.Comp8, _ comp9: R.Comp9, _ comp10: R.Comp10, _ comp11: R.Comp11, _ comp12: R.Comp12) -> (R.Components) {
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12)
+    }
+}
+
+extension Requires12: FamilyEncoding where Comp1: Encodable, Comp2: Encodable, Comp3: Encodable, Comp4: Encodable, Comp5: Encodable, Comp6: Encodable, Comp7: Encodable, Comp8: Encodable, Comp9: Encodable, Comp10: Encodable, Comp11: Encodable, Comp12: Encodable {
+    public static func encode(components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12), into container: inout KeyedEncodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws {
+        try container.encode(components.0, forKey: strategy.codingKey(for: Comp1.self))
+        try container.encode(components.1, forKey: strategy.codingKey(for: Comp2.self))
+        try container.encode(components.2, forKey: strategy.codingKey(for: Comp3.self))
+        try container.encode(components.3, forKey: strategy.codingKey(for: Comp4.self))
+        try container.encode(components.4, forKey: strategy.codingKey(for: Comp5.self))
+        try container.encode(components.5, forKey: strategy.codingKey(for: Comp6.self))
+        try container.encode(components.6, forKey: strategy.codingKey(for: Comp7.self))
+        try container.encode(components.7, forKey: strategy.codingKey(for: Comp8.self))
+        try container.encode(components.8, forKey: strategy.codingKey(for: Comp9.self))
+        try container.encode(components.9, forKey: strategy.codingKey(for: Comp10.self))
+        try container.encode(components.10, forKey: strategy.codingKey(for: Comp11.self))
+        try container.encode(components.11, forKey: strategy.codingKey(for: Comp12.self))
+    }
+}
+
+extension Requires12: FamilyDecoding where Comp1: Decodable, Comp2: Decodable, Comp3: Decodable, Comp4: Decodable, Comp5: Decodable, Comp6: Decodable, Comp7: Decodable, Comp8: Decodable, Comp9: Decodable, Comp10: Decodable, Comp11: Decodable, Comp12: Decodable {
+    public static func decode(componentsIn container: KeyedDecodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12) {
+        let comp1 = try container.decode(Comp1.self, forKey: strategy.codingKey(for: Comp1.self))
+        let comp2 = try container.decode(Comp2.self, forKey: strategy.codingKey(for: Comp2.self))
+        let comp3 = try container.decode(Comp3.self, forKey: strategy.codingKey(for: Comp3.self))
+        let comp4 = try container.decode(Comp4.self, forKey: strategy.codingKey(for: Comp4.self))
+        let comp5 = try container.decode(Comp5.self, forKey: strategy.codingKey(for: Comp5.self))
+        let comp6 = try container.decode(Comp6.self, forKey: strategy.codingKey(for: Comp6.self))
+        let comp7 = try container.decode(Comp7.self, forKey: strategy.codingKey(for: Comp7.self))
+        let comp8 = try container.decode(Comp8.self, forKey: strategy.codingKey(for: Comp8.self))
+        let comp9 = try container.decode(Comp9.self, forKey: strategy.codingKey(for: Comp9.self))
+        let comp10 = try container.decode(Comp10.self, forKey: strategy.codingKey(for: Comp10.self))
+        let comp11 = try container.decode(Comp11.self, forKey: strategy.codingKey(for: Comp11.self))
+        let comp12 = try container.decode(Comp12.self, forKey: strategy.codingKey(for: Comp12.self))
+        return Components(comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12)
+    }
+}
+
+extension Nexus {
+    /// Create a family of entities (aka members) having 12 required components.
+    ///
+    /// A family is a collection of entities with uniform component types per entity.
+    /// Entities that are be part of this family will have at least the 12 required components,
+    /// but may have more components assigned.
+    ///
+    /// A family is just a view on (component) data, creating them is cheap.
+    /// Use them to iterate efficiently over entities with the same components assigned.
+    /// Families with the same requirements provide a view on the same collection of entities (aka members).
+    /// A family conforms to the `LazySequenceProtocol` and therefore can be accessed like any other (lazy) sequence.
+    ///
+    /// **General usage**
+    /// ```swift
+    /// let family = nexus.family(requiresAll: Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self, Comp12.self)
+    /// // iterate each entity's components
+    /// family.forEach { (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12) in
+    ///   ...
+    /// }
+    /// ```
+    /// **Caveats**
+    /// - Component types must be unique per family
+    /// - Component type order is arbitrary
+    ///
+    /// - Parameters:
+    ///   - comp1: Component type 1 required by members of this family.
+    ///   - comp2: Component type 2 required by members of this family.
+    ///   - comp3: Component type 3 required by members of this family.
+    ///   - comp4: Component type 4 required by members of this family.
+    ///   - comp5: Component type 5 required by members of this family.
+    ///   - comp6: Component type 6 required by members of this family.
+    ///   - comp7: Component type 7 required by members of this family.
+    ///   - comp8: Component type 8 required by members of this family.
+    ///   - comp9: Component type 9 required by members of this family.
+    ///   - comp10: Component type 10 required by members of this family.
+    ///   - comp11: Component type 11 required by members of this family.
+    ///   - comp12: Component type 12 required by members of this family.
+    ///   - excludedComponents: All component types that must not be assigned to an entity in this family.
+    /// - Returns: The family of entities having 12 required components each.
+    public func family<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12>(
+        requiresAll comp1: Comp1.Type, _ comp2: Comp2.Type, _ comp3: Comp3.Type, _ comp4: Comp4.Type, _ comp5: Comp5.Type, _ comp6: Comp6.Type, _ comp7: Comp7.Type, _ comp8: Comp8.Type, _ comp9: Comp9.Type, _ comp10: Comp10.Type, _ comp11: Comp11.Type, _ comp12: Comp12.Type,
+        excludesAll excludedComponents: Component.Type...
+    ) -> Family12<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component {
+        Family12<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12>(
+            nexus: self,
+            requiresAll: (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12),
+            excludesAll: excludedComponents
+        )
+    }
+}
+
+// MARK: - Family 13
+
+public typealias Family13<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13> = Family<Requires13<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13>> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component
+
+public protocol RequiringComponents13: FamilyRequirementsManaging where Components == (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13) {
+    associatedtype Comp1: Component
+    associatedtype Comp2: Component
+    associatedtype Comp3: Component
+    associatedtype Comp4: Component
+    associatedtype Comp5: Component
+    associatedtype Comp6: Component
+    associatedtype Comp7: Component
+    associatedtype Comp8: Component
+    associatedtype Comp9: Component
+    associatedtype Comp10: Component
+    associatedtype Comp11: Component
+    associatedtype Comp12: Component
+    associatedtype Comp13: Component
+}
+
+public struct Requires13<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13>: FamilyRequirementsManaging where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component {
+    public let componentTypes: [Component.Type]
+
+    public init(_ components: (Comp1.Type, Comp2.Type, Comp3.Type, Comp4.Type, Comp5.Type, Comp6.Type, Comp7.Type, Comp8.Type, Comp9.Type, Comp10.Type, Comp11.Type, Comp12.Type, Comp13.Type)) {
+        componentTypes = [Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self, Comp12.self, Comp13.self]
+    }
+
+    public static func components(nexus: Nexus, entityId: EntityIdentifier) -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13) {
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        let comp12: Comp12 = nexus.get(unsafe: entityId)
+        let comp13: Comp13 = nexus.get(unsafe: entityId)
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13)
+    }
+
+    public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13) {
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        let comp12: Comp12 = nexus.get(unsafe: entityId)
+        let comp13: Comp13 = nexus.get(unsafe: entityId)
+        return (entity, comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13)
+    }
+
+    public static func createMember(nexus: Nexus, components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13)) -> Entity {
+        nexus.createEntity(with: components.0, components.1, components.2, components.3, components.4, components.5, components.6, components.7, components.8, components.9, components.10, components.11, components.12)
+    }
+}
+
+extension Requires13: RequiringComponents13 { }
+
+extension FamilyMemberBuilder where R: RequiringComponents13  {
+    public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5, _ comp6: R.Comp6, _ comp7: R.Comp7, _ comp8: R.Comp8, _ comp9: R.Comp9, _ comp10: R.Comp10, _ comp11: R.Comp11, _ comp12: R.Comp12, _ comp13: R.Comp13) -> (R.Components) {
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13)
+    }
+}
+
+extension Requires13: FamilyEncoding where Comp1: Encodable, Comp2: Encodable, Comp3: Encodable, Comp4: Encodable, Comp5: Encodable, Comp6: Encodable, Comp7: Encodable, Comp8: Encodable, Comp9: Encodable, Comp10: Encodable, Comp11: Encodable, Comp12: Encodable, Comp13: Encodable {
+    public static func encode(components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13), into container: inout KeyedEncodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws {
+        try container.encode(components.0, forKey: strategy.codingKey(for: Comp1.self))
+        try container.encode(components.1, forKey: strategy.codingKey(for: Comp2.self))
+        try container.encode(components.2, forKey: strategy.codingKey(for: Comp3.self))
+        try container.encode(components.3, forKey: strategy.codingKey(for: Comp4.self))
+        try container.encode(components.4, forKey: strategy.codingKey(for: Comp5.self))
+        try container.encode(components.5, forKey: strategy.codingKey(for: Comp6.self))
+        try container.encode(components.6, forKey: strategy.codingKey(for: Comp7.self))
+        try container.encode(components.7, forKey: strategy.codingKey(for: Comp8.self))
+        try container.encode(components.8, forKey: strategy.codingKey(for: Comp9.self))
+        try container.encode(components.9, forKey: strategy.codingKey(for: Comp10.self))
+        try container.encode(components.10, forKey: strategy.codingKey(for: Comp11.self))
+        try container.encode(components.11, forKey: strategy.codingKey(for: Comp12.self))
+        try container.encode(components.12, forKey: strategy.codingKey(for: Comp13.self))
+    }
+}
+
+extension Requires13: FamilyDecoding where Comp1: Decodable, Comp2: Decodable, Comp3: Decodable, Comp4: Decodable, Comp5: Decodable, Comp6: Decodable, Comp7: Decodable, Comp8: Decodable, Comp9: Decodable, Comp10: Decodable, Comp11: Decodable, Comp12: Decodable, Comp13: Decodable {
+    public static func decode(componentsIn container: KeyedDecodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13) {
+        let comp1 = try container.decode(Comp1.self, forKey: strategy.codingKey(for: Comp1.self))
+        let comp2 = try container.decode(Comp2.self, forKey: strategy.codingKey(for: Comp2.self))
+        let comp3 = try container.decode(Comp3.self, forKey: strategy.codingKey(for: Comp3.self))
+        let comp4 = try container.decode(Comp4.self, forKey: strategy.codingKey(for: Comp4.self))
+        let comp5 = try container.decode(Comp5.self, forKey: strategy.codingKey(for: Comp5.self))
+        let comp6 = try container.decode(Comp6.self, forKey: strategy.codingKey(for: Comp6.self))
+        let comp7 = try container.decode(Comp7.self, forKey: strategy.codingKey(for: Comp7.self))
+        let comp8 = try container.decode(Comp8.self, forKey: strategy.codingKey(for: Comp8.self))
+        let comp9 = try container.decode(Comp9.self, forKey: strategy.codingKey(for: Comp9.self))
+        let comp10 = try container.decode(Comp10.self, forKey: strategy.codingKey(for: Comp10.self))
+        let comp11 = try container.decode(Comp11.self, forKey: strategy.codingKey(for: Comp11.self))
+        let comp12 = try container.decode(Comp12.self, forKey: strategy.codingKey(for: Comp12.self))
+        let comp13 = try container.decode(Comp13.self, forKey: strategy.codingKey(for: Comp13.self))
+        return Components(comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13)
+    }
+}
+
+extension Nexus {
+    /// Create a family of entities (aka members) having 13 required components.
+    ///
+    /// A family is a collection of entities with uniform component types per entity.
+    /// Entities that are be part of this family will have at least the 13 required components,
+    /// but may have more components assigned.
+    ///
+    /// A family is just a view on (component) data, creating them is cheap.
+    /// Use them to iterate efficiently over entities with the same components assigned.
+    /// Families with the same requirements provide a view on the same collection of entities (aka members).
+    /// A family conforms to the `LazySequenceProtocol` and therefore can be accessed like any other (lazy) sequence.
+    ///
+    /// **General usage**
+    /// ```swift
+    /// let family = nexus.family(requiresAll: Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self, Comp12.self, Comp13.self)
+    /// // iterate each entity's components
+    /// family.forEach { (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13) in
+    ///   ...
+    /// }
+    /// ```
+    /// **Caveats**
+    /// - Component types must be unique per family
+    /// - Component type order is arbitrary
+    ///
+    /// - Parameters:
+    ///   - comp1: Component type 1 required by members of this family.
+    ///   - comp2: Component type 2 required by members of this family.
+    ///   - comp3: Component type 3 required by members of this family.
+    ///   - comp4: Component type 4 required by members of this family.
+    ///   - comp5: Component type 5 required by members of this family.
+    ///   - comp6: Component type 6 required by members of this family.
+    ///   - comp7: Component type 7 required by members of this family.
+    ///   - comp8: Component type 8 required by members of this family.
+    ///   - comp9: Component type 9 required by members of this family.
+    ///   - comp10: Component type 10 required by members of this family.
+    ///   - comp11: Component type 11 required by members of this family.
+    ///   - comp12: Component type 12 required by members of this family.
+    ///   - comp13: Component type 13 required by members of this family.
+    ///   - excludedComponents: All component types that must not be assigned to an entity in this family.
+    /// - Returns: The family of entities having 13 required components each.
+    public func family<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13>(
+        requiresAll comp1: Comp1.Type, _ comp2: Comp2.Type, _ comp3: Comp3.Type, _ comp4: Comp4.Type, _ comp5: Comp5.Type, _ comp6: Comp6.Type, _ comp7: Comp7.Type, _ comp8: Comp8.Type, _ comp9: Comp9.Type, _ comp10: Comp10.Type, _ comp11: Comp11.Type, _ comp12: Comp12.Type, _ comp13: Comp13.Type,
+        excludesAll excludedComponents: Component.Type...
+    ) -> Family13<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component {
+        Family13<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13>(
+            nexus: self,
+            requiresAll: (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13),
+            excludesAll: excludedComponents
+        )
+    }
+}
+
+// MARK: - Family 14
+
+public typealias Family14<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14> = Family<Requires14<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14>> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component, Comp14: Component
+
+public protocol RequiringComponents14: FamilyRequirementsManaging where Components == (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14) {
+    associatedtype Comp1: Component
+    associatedtype Comp2: Component
+    associatedtype Comp3: Component
+    associatedtype Comp4: Component
+    associatedtype Comp5: Component
+    associatedtype Comp6: Component
+    associatedtype Comp7: Component
+    associatedtype Comp8: Component
+    associatedtype Comp9: Component
+    associatedtype Comp10: Component
+    associatedtype Comp11: Component
+    associatedtype Comp12: Component
+    associatedtype Comp13: Component
+    associatedtype Comp14: Component
+}
+
+public struct Requires14<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14>: FamilyRequirementsManaging where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component, Comp14: Component {
+    public let componentTypes: [Component.Type]
+
+    public init(_ components: (Comp1.Type, Comp2.Type, Comp3.Type, Comp4.Type, Comp5.Type, Comp6.Type, Comp7.Type, Comp8.Type, Comp9.Type, Comp10.Type, Comp11.Type, Comp12.Type, Comp13.Type, Comp14.Type)) {
+        componentTypes = [Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self, Comp12.self, Comp13.self, Comp14.self]
+    }
+
+    public static func components(nexus: Nexus, entityId: EntityIdentifier) -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14) {
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        let comp12: Comp12 = nexus.get(unsafe: entityId)
+        let comp13: Comp13 = nexus.get(unsafe: entityId)
+        let comp14: Comp14 = nexus.get(unsafe: entityId)
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14)
+    }
+
+    public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14) {
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        let comp12: Comp12 = nexus.get(unsafe: entityId)
+        let comp13: Comp13 = nexus.get(unsafe: entityId)
+        let comp14: Comp14 = nexus.get(unsafe: entityId)
+        return (entity, comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14)
+    }
+
+    public static func createMember(nexus: Nexus, components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14)) -> Entity {
+        nexus.createEntity(with: components.0, components.1, components.2, components.3, components.4, components.5, components.6, components.7, components.8, components.9, components.10, components.11, components.12, components.13)
+    }
+}
+
+extension Requires14: RequiringComponents14 { }
+
+extension FamilyMemberBuilder where R: RequiringComponents14  {
+    public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5, _ comp6: R.Comp6, _ comp7: R.Comp7, _ comp8: R.Comp8, _ comp9: R.Comp9, _ comp10: R.Comp10, _ comp11: R.Comp11, _ comp12: R.Comp12, _ comp13: R.Comp13, _ comp14: R.Comp14) -> (R.Components) {
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14)
+    }
+}
+
+extension Requires14: FamilyEncoding where Comp1: Encodable, Comp2: Encodable, Comp3: Encodable, Comp4: Encodable, Comp5: Encodable, Comp6: Encodable, Comp7: Encodable, Comp8: Encodable, Comp9: Encodable, Comp10: Encodable, Comp11: Encodable, Comp12: Encodable, Comp13: Encodable, Comp14: Encodable {
+    public static func encode(components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14), into container: inout KeyedEncodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws {
+        try container.encode(components.0, forKey: strategy.codingKey(for: Comp1.self))
+        try container.encode(components.1, forKey: strategy.codingKey(for: Comp2.self))
+        try container.encode(components.2, forKey: strategy.codingKey(for: Comp3.self))
+        try container.encode(components.3, forKey: strategy.codingKey(for: Comp4.self))
+        try container.encode(components.4, forKey: strategy.codingKey(for: Comp5.self))
+        try container.encode(components.5, forKey: strategy.codingKey(for: Comp6.self))
+        try container.encode(components.6, forKey: strategy.codingKey(for: Comp7.self))
+        try container.encode(components.7, forKey: strategy.codingKey(for: Comp8.self))
+        try container.encode(components.8, forKey: strategy.codingKey(for: Comp9.self))
+        try container.encode(components.9, forKey: strategy.codingKey(for: Comp10.self))
+        try container.encode(components.10, forKey: strategy.codingKey(for: Comp11.self))
+        try container.encode(components.11, forKey: strategy.codingKey(for: Comp12.self))
+        try container.encode(components.12, forKey: strategy.codingKey(for: Comp13.self))
+        try container.encode(components.13, forKey: strategy.codingKey(for: Comp14.self))
+    }
+}
+
+extension Requires14: FamilyDecoding where Comp1: Decodable, Comp2: Decodable, Comp3: Decodable, Comp4: Decodable, Comp5: Decodable, Comp6: Decodable, Comp7: Decodable, Comp8: Decodable, Comp9: Decodable, Comp10: Decodable, Comp11: Decodable, Comp12: Decodable, Comp13: Decodable, Comp14: Decodable {
+    public static func decode(componentsIn container: KeyedDecodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14) {
+        let comp1 = try container.decode(Comp1.self, forKey: strategy.codingKey(for: Comp1.self))
+        let comp2 = try container.decode(Comp2.self, forKey: strategy.codingKey(for: Comp2.self))
+        let comp3 = try container.decode(Comp3.self, forKey: strategy.codingKey(for: Comp3.self))
+        let comp4 = try container.decode(Comp4.self, forKey: strategy.codingKey(for: Comp4.self))
+        let comp5 = try container.decode(Comp5.self, forKey: strategy.codingKey(for: Comp5.self))
+        let comp6 = try container.decode(Comp6.self, forKey: strategy.codingKey(for: Comp6.self))
+        let comp7 = try container.decode(Comp7.self, forKey: strategy.codingKey(for: Comp7.self))
+        let comp8 = try container.decode(Comp8.self, forKey: strategy.codingKey(for: Comp8.self))
+        let comp9 = try container.decode(Comp9.self, forKey: strategy.codingKey(for: Comp9.self))
+        let comp10 = try container.decode(Comp10.self, forKey: strategy.codingKey(for: Comp10.self))
+        let comp11 = try container.decode(Comp11.self, forKey: strategy.codingKey(for: Comp11.self))
+        let comp12 = try container.decode(Comp12.self, forKey: strategy.codingKey(for: Comp12.self))
+        let comp13 = try container.decode(Comp13.self, forKey: strategy.codingKey(for: Comp13.self))
+        let comp14 = try container.decode(Comp14.self, forKey: strategy.codingKey(for: Comp14.self))
+        return Components(comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14)
+    }
+}
+
+extension Nexus {
+    /// Create a family of entities (aka members) having 14 required components.
+    ///
+    /// A family is a collection of entities with uniform component types per entity.
+    /// Entities that are be part of this family will have at least the 14 required components,
+    /// but may have more components assigned.
+    ///
+    /// A family is just a view on (component) data, creating them is cheap.
+    /// Use them to iterate efficiently over entities with the same components assigned.
+    /// Families with the same requirements provide a view on the same collection of entities (aka members).
+    /// A family conforms to the `LazySequenceProtocol` and therefore can be accessed like any other (lazy) sequence.
+    ///
+    /// **General usage**
+    /// ```swift
+    /// let family = nexus.family(requiresAll: Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self, Comp12.self, Comp13.self, Comp14.self)
+    /// // iterate each entity's components
+    /// family.forEach { (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14) in
+    ///   ...
+    /// }
+    /// ```
+    /// **Caveats**
+    /// - Component types must be unique per family
+    /// - Component type order is arbitrary
+    ///
+    /// - Parameters:
+    ///   - comp1: Component type 1 required by members of this family.
+    ///   - comp2: Component type 2 required by members of this family.
+    ///   - comp3: Component type 3 required by members of this family.
+    ///   - comp4: Component type 4 required by members of this family.
+    ///   - comp5: Component type 5 required by members of this family.
+    ///   - comp6: Component type 6 required by members of this family.
+    ///   - comp7: Component type 7 required by members of this family.
+    ///   - comp8: Component type 8 required by members of this family.
+    ///   - comp9: Component type 9 required by members of this family.
+    ///   - comp10: Component type 10 required by members of this family.
+    ///   - comp11: Component type 11 required by members of this family.
+    ///   - comp12: Component type 12 required by members of this family.
+    ///   - comp13: Component type 13 required by members of this family.
+    ///   - comp14: Component type 14 required by members of this family.
+    ///   - excludedComponents: All component types that must not be assigned to an entity in this family.
+    /// - Returns: The family of entities having 14 required components each.
+    public func family<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14>(
+        requiresAll comp1: Comp1.Type, _ comp2: Comp2.Type, _ comp3: Comp3.Type, _ comp4: Comp4.Type, _ comp5: Comp5.Type, _ comp6: Comp6.Type, _ comp7: Comp7.Type, _ comp8: Comp8.Type, _ comp9: Comp9.Type, _ comp10: Comp10.Type, _ comp11: Comp11.Type, _ comp12: Comp12.Type, _ comp13: Comp13.Type, _ comp14: Comp14.Type,
+        excludesAll excludedComponents: Component.Type...
+    ) -> Family14<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component, Comp14: Component {
+        Family14<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14>(
+            nexus: self,
+            requiresAll: (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14),
+            excludesAll: excludedComponents
+        )
+    }
+}
+
+// MARK: - Family 15
+
+public typealias Family15<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15> = Family<Requires15<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15>> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component, Comp14: Component, Comp15: Component
+
+public protocol RequiringComponents15: FamilyRequirementsManaging where Components == (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15) {
+    associatedtype Comp1: Component
+    associatedtype Comp2: Component
+    associatedtype Comp3: Component
+    associatedtype Comp4: Component
+    associatedtype Comp5: Component
+    associatedtype Comp6: Component
+    associatedtype Comp7: Component
+    associatedtype Comp8: Component
+    associatedtype Comp9: Component
+    associatedtype Comp10: Component
+    associatedtype Comp11: Component
+    associatedtype Comp12: Component
+    associatedtype Comp13: Component
+    associatedtype Comp14: Component
+    associatedtype Comp15: Component
+}
+
+public struct Requires15<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15>: FamilyRequirementsManaging where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component, Comp14: Component, Comp15: Component {
+    public let componentTypes: [Component.Type]
+
+    public init(_ components: (Comp1.Type, Comp2.Type, Comp3.Type, Comp4.Type, Comp5.Type, Comp6.Type, Comp7.Type, Comp8.Type, Comp9.Type, Comp10.Type, Comp11.Type, Comp12.Type, Comp13.Type, Comp14.Type, Comp15.Type)) {
+        componentTypes = [Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self, Comp12.self, Comp13.self, Comp14.self, Comp15.self]
+    }
+
+    public static func components(nexus: Nexus, entityId: EntityIdentifier) -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15) {
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        let comp12: Comp12 = nexus.get(unsafe: entityId)
+        let comp13: Comp13 = nexus.get(unsafe: entityId)
+        let comp14: Comp14 = nexus.get(unsafe: entityId)
+        let comp15: Comp15 = nexus.get(unsafe: entityId)
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15)
+    }
+
+    public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15) {
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        let comp12: Comp12 = nexus.get(unsafe: entityId)
+        let comp13: Comp13 = nexus.get(unsafe: entityId)
+        let comp14: Comp14 = nexus.get(unsafe: entityId)
+        let comp15: Comp15 = nexus.get(unsafe: entityId)
+        return (entity, comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15)
+    }
+
+    public static func createMember(nexus: Nexus, components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15)) -> Entity {
+        nexus.createEntity(with: components.0, components.1, components.2, components.3, components.4, components.5, components.6, components.7, components.8, components.9, components.10, components.11, components.12, components.13, components.14)
+    }
+}
+
+extension Requires15: RequiringComponents15 { }
+
+extension FamilyMemberBuilder where R: RequiringComponents15  {
+    public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5, _ comp6: R.Comp6, _ comp7: R.Comp7, _ comp8: R.Comp8, _ comp9: R.Comp9, _ comp10: R.Comp10, _ comp11: R.Comp11, _ comp12: R.Comp12, _ comp13: R.Comp13, _ comp14: R.Comp14, _ comp15: R.Comp15) -> (R.Components) {
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15)
+    }
+}
+
+extension Requires15: FamilyEncoding where Comp1: Encodable, Comp2: Encodable, Comp3: Encodable, Comp4: Encodable, Comp5: Encodable, Comp6: Encodable, Comp7: Encodable, Comp8: Encodable, Comp9: Encodable, Comp10: Encodable, Comp11: Encodable, Comp12: Encodable, Comp13: Encodable, Comp14: Encodable, Comp15: Encodable {
+    public static func encode(components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15), into container: inout KeyedEncodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws {
+        try container.encode(components.0, forKey: strategy.codingKey(for: Comp1.self))
+        try container.encode(components.1, forKey: strategy.codingKey(for: Comp2.self))
+        try container.encode(components.2, forKey: strategy.codingKey(for: Comp3.self))
+        try container.encode(components.3, forKey: strategy.codingKey(for: Comp4.self))
+        try container.encode(components.4, forKey: strategy.codingKey(for: Comp5.self))
+        try container.encode(components.5, forKey: strategy.codingKey(for: Comp6.self))
+        try container.encode(components.6, forKey: strategy.codingKey(for: Comp7.self))
+        try container.encode(components.7, forKey: strategy.codingKey(for: Comp8.self))
+        try container.encode(components.8, forKey: strategy.codingKey(for: Comp9.self))
+        try container.encode(components.9, forKey: strategy.codingKey(for: Comp10.self))
+        try container.encode(components.10, forKey: strategy.codingKey(for: Comp11.self))
+        try container.encode(components.11, forKey: strategy.codingKey(for: Comp12.self))
+        try container.encode(components.12, forKey: strategy.codingKey(for: Comp13.self))
+        try container.encode(components.13, forKey: strategy.codingKey(for: Comp14.self))
+        try container.encode(components.14, forKey: strategy.codingKey(for: Comp15.self))
+    }
+}
+
+extension Requires15: FamilyDecoding where Comp1: Decodable, Comp2: Decodable, Comp3: Decodable, Comp4: Decodable, Comp5: Decodable, Comp6: Decodable, Comp7: Decodable, Comp8: Decodable, Comp9: Decodable, Comp10: Decodable, Comp11: Decodable, Comp12: Decodable, Comp13: Decodable, Comp14: Decodable, Comp15: Decodable {
+    public static func decode(componentsIn container: KeyedDecodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15) {
+        let comp1 = try container.decode(Comp1.self, forKey: strategy.codingKey(for: Comp1.self))
+        let comp2 = try container.decode(Comp2.self, forKey: strategy.codingKey(for: Comp2.self))
+        let comp3 = try container.decode(Comp3.self, forKey: strategy.codingKey(for: Comp3.self))
+        let comp4 = try container.decode(Comp4.self, forKey: strategy.codingKey(for: Comp4.self))
+        let comp5 = try container.decode(Comp5.self, forKey: strategy.codingKey(for: Comp5.self))
+        let comp6 = try container.decode(Comp6.self, forKey: strategy.codingKey(for: Comp6.self))
+        let comp7 = try container.decode(Comp7.self, forKey: strategy.codingKey(for: Comp7.self))
+        let comp8 = try container.decode(Comp8.self, forKey: strategy.codingKey(for: Comp8.self))
+        let comp9 = try container.decode(Comp9.self, forKey: strategy.codingKey(for: Comp9.self))
+        let comp10 = try container.decode(Comp10.self, forKey: strategy.codingKey(for: Comp10.self))
+        let comp11 = try container.decode(Comp11.self, forKey: strategy.codingKey(for: Comp11.self))
+        let comp12 = try container.decode(Comp12.self, forKey: strategy.codingKey(for: Comp12.self))
+        let comp13 = try container.decode(Comp13.self, forKey: strategy.codingKey(for: Comp13.self))
+        let comp14 = try container.decode(Comp14.self, forKey: strategy.codingKey(for: Comp14.self))
+        let comp15 = try container.decode(Comp15.self, forKey: strategy.codingKey(for: Comp15.self))
+        return Components(comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15)
+    }
+}
+
+extension Nexus {
+    /// Create a family of entities (aka members) having 15 required components.
+    ///
+    /// A family is a collection of entities with uniform component types per entity.
+    /// Entities that are be part of this family will have at least the 15 required components,
+    /// but may have more components assigned.
+    ///
+    /// A family is just a view on (component) data, creating them is cheap.
+    /// Use them to iterate efficiently over entities with the same components assigned.
+    /// Families with the same requirements provide a view on the same collection of entities (aka members).
+    /// A family conforms to the `LazySequenceProtocol` and therefore can be accessed like any other (lazy) sequence.
+    ///
+    /// **General usage**
+    /// ```swift
+    /// let family = nexus.family(requiresAll: Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self, Comp12.self, Comp13.self, Comp14.self, Comp15.self)
+    /// // iterate each entity's components
+    /// family.forEach { (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15) in
+    ///   ...
+    /// }
+    /// ```
+    /// **Caveats**
+    /// - Component types must be unique per family
+    /// - Component type order is arbitrary
+    ///
+    /// - Parameters:
+    ///   - comp1: Component type 1 required by members of this family.
+    ///   - comp2: Component type 2 required by members of this family.
+    ///   - comp3: Component type 3 required by members of this family.
+    ///   - comp4: Component type 4 required by members of this family.
+    ///   - comp5: Component type 5 required by members of this family.
+    ///   - comp6: Component type 6 required by members of this family.
+    ///   - comp7: Component type 7 required by members of this family.
+    ///   - comp8: Component type 8 required by members of this family.
+    ///   - comp9: Component type 9 required by members of this family.
+    ///   - comp10: Component type 10 required by members of this family.
+    ///   - comp11: Component type 11 required by members of this family.
+    ///   - comp12: Component type 12 required by members of this family.
+    ///   - comp13: Component type 13 required by members of this family.
+    ///   - comp14: Component type 14 required by members of this family.
+    ///   - comp15: Component type 15 required by members of this family.
+    ///   - excludedComponents: All component types that must not be assigned to an entity in this family.
+    /// - Returns: The family of entities having 15 required components each.
+    public func family<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15>(
+        requiresAll comp1: Comp1.Type, _ comp2: Comp2.Type, _ comp3: Comp3.Type, _ comp4: Comp4.Type, _ comp5: Comp5.Type, _ comp6: Comp6.Type, _ comp7: Comp7.Type, _ comp8: Comp8.Type, _ comp9: Comp9.Type, _ comp10: Comp10.Type, _ comp11: Comp11.Type, _ comp12: Comp12.Type, _ comp13: Comp13.Type, _ comp14: Comp14.Type, _ comp15: Comp15.Type,
+        excludesAll excludedComponents: Component.Type...
+    ) -> Family15<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component, Comp14: Component, Comp15: Component {
+        Family15<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15>(
+            nexus: self,
+            requiresAll: (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15),
+            excludesAll: excludedComponents
+        )
+    }
+}
+
+// MARK: - Family 16
+
+public typealias Family16<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16> = Family<Requires16<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16>> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component, Comp14: Component, Comp15: Component, Comp16: Component
+
+public protocol RequiringComponents16: FamilyRequirementsManaging where Components == (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16) {
+    associatedtype Comp1: Component
+    associatedtype Comp2: Component
+    associatedtype Comp3: Component
+    associatedtype Comp4: Component
+    associatedtype Comp5: Component
+    associatedtype Comp6: Component
+    associatedtype Comp7: Component
+    associatedtype Comp8: Component
+    associatedtype Comp9: Component
+    associatedtype Comp10: Component
+    associatedtype Comp11: Component
+    associatedtype Comp12: Component
+    associatedtype Comp13: Component
+    associatedtype Comp14: Component
+    associatedtype Comp15: Component
+    associatedtype Comp16: Component
+}
+
+public struct Requires16<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16>: FamilyRequirementsManaging where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component, Comp14: Component, Comp15: Component, Comp16: Component {
+    public let componentTypes: [Component.Type]
+
+    public init(_ components: (Comp1.Type, Comp2.Type, Comp3.Type, Comp4.Type, Comp5.Type, Comp6.Type, Comp7.Type, Comp8.Type, Comp9.Type, Comp10.Type, Comp11.Type, Comp12.Type, Comp13.Type, Comp14.Type, Comp15.Type, Comp16.Type)) {
+        componentTypes = [Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self, Comp12.self, Comp13.self, Comp14.self, Comp15.self, Comp16.self]
+    }
+
+    public static func components(nexus: Nexus, entityId: EntityIdentifier) -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16) {
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        let comp12: Comp12 = nexus.get(unsafe: entityId)
+        let comp13: Comp13 = nexus.get(unsafe: entityId)
+        let comp14: Comp14 = nexus.get(unsafe: entityId)
+        let comp15: Comp15 = nexus.get(unsafe: entityId)
+        let comp16: Comp16 = nexus.get(unsafe: entityId)
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15, comp16)
+    }
+
+    public static func entityAndComponents(nexus: Nexus, entityId: EntityIdentifier) -> (Entity, Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16) {
+        let entity: Entity = Entity(nexus: nexus, id: entityId)
+        let comp1: Comp1 = nexus.get(unsafe: entityId)
+        let comp2: Comp2 = nexus.get(unsafe: entityId)
+        let comp3: Comp3 = nexus.get(unsafe: entityId)
+        let comp4: Comp4 = nexus.get(unsafe: entityId)
+        let comp5: Comp5 = nexus.get(unsafe: entityId)
+        let comp6: Comp6 = nexus.get(unsafe: entityId)
+        let comp7: Comp7 = nexus.get(unsafe: entityId)
+        let comp8: Comp8 = nexus.get(unsafe: entityId)
+        let comp9: Comp9 = nexus.get(unsafe: entityId)
+        let comp10: Comp10 = nexus.get(unsafe: entityId)
+        let comp11: Comp11 = nexus.get(unsafe: entityId)
+        let comp12: Comp12 = nexus.get(unsafe: entityId)
+        let comp13: Comp13 = nexus.get(unsafe: entityId)
+        let comp14: Comp14 = nexus.get(unsafe: entityId)
+        let comp15: Comp15 = nexus.get(unsafe: entityId)
+        let comp16: Comp16 = nexus.get(unsafe: entityId)
+        return (entity, comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15, comp16)
+    }
+
+    public static func createMember(nexus: Nexus, components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16)) -> Entity {
+        nexus.createEntity(with: components.0, components.1, components.2, components.3, components.4, components.5, components.6, components.7, components.8, components.9, components.10, components.11, components.12, components.13, components.14, components.15)
+    }
+}
+
+extension Requires16: RequiringComponents16 { }
+
+extension FamilyMemberBuilder where R: RequiringComponents16  {
+    public static func buildBlock(_ comp1: R.Comp1, _ comp2: R.Comp2, _ comp3: R.Comp3, _ comp4: R.Comp4, _ comp5: R.Comp5, _ comp6: R.Comp6, _ comp7: R.Comp7, _ comp8: R.Comp8, _ comp9: R.Comp9, _ comp10: R.Comp10, _ comp11: R.Comp11, _ comp12: R.Comp12, _ comp13: R.Comp13, _ comp14: R.Comp14, _ comp15: R.Comp15, _ comp16: R.Comp16) -> (R.Components) {
+        return (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15, comp16)
+    }
+}
+
+extension Requires16: FamilyEncoding where Comp1: Encodable, Comp2: Encodable, Comp3: Encodable, Comp4: Encodable, Comp5: Encodable, Comp6: Encodable, Comp7: Encodable, Comp8: Encodable, Comp9: Encodable, Comp10: Encodable, Comp11: Encodable, Comp12: Encodable, Comp13: Encodable, Comp14: Encodable, Comp15: Encodable, Comp16: Encodable {
+    public static func encode(components: (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16), into container: inout KeyedEncodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws {
+        try container.encode(components.0, forKey: strategy.codingKey(for: Comp1.self))
+        try container.encode(components.1, forKey: strategy.codingKey(for: Comp2.self))
+        try container.encode(components.2, forKey: strategy.codingKey(for: Comp3.self))
+        try container.encode(components.3, forKey: strategy.codingKey(for: Comp4.self))
+        try container.encode(components.4, forKey: strategy.codingKey(for: Comp5.self))
+        try container.encode(components.5, forKey: strategy.codingKey(for: Comp6.self))
+        try container.encode(components.6, forKey: strategy.codingKey(for: Comp7.self))
+        try container.encode(components.7, forKey: strategy.codingKey(for: Comp8.self))
+        try container.encode(components.8, forKey: strategy.codingKey(for: Comp9.self))
+        try container.encode(components.9, forKey: strategy.codingKey(for: Comp10.self))
+        try container.encode(components.10, forKey: strategy.codingKey(for: Comp11.self))
+        try container.encode(components.11, forKey: strategy.codingKey(for: Comp12.self))
+        try container.encode(components.12, forKey: strategy.codingKey(for: Comp13.self))
+        try container.encode(components.13, forKey: strategy.codingKey(for: Comp14.self))
+        try container.encode(components.14, forKey: strategy.codingKey(for: Comp15.self))
+        try container.encode(components.15, forKey: strategy.codingKey(for: Comp16.self))
+    }
+}
+
+extension Requires16: FamilyDecoding where Comp1: Decodable, Comp2: Decodable, Comp3: Decodable, Comp4: Decodable, Comp5: Decodable, Comp6: Decodable, Comp7: Decodable, Comp8: Decodable, Comp9: Decodable, Comp10: Decodable, Comp11: Decodable, Comp12: Decodable, Comp13: Decodable, Comp14: Decodable, Comp15: Decodable, Comp16: Decodable {
+    public static func decode(componentsIn container: KeyedDecodingContainer<DynamicCodingKey>, using strategy: CodingStrategy) throws -> (Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16) {
+        let comp1 = try container.decode(Comp1.self, forKey: strategy.codingKey(for: Comp1.self))
+        let comp2 = try container.decode(Comp2.self, forKey: strategy.codingKey(for: Comp2.self))
+        let comp3 = try container.decode(Comp3.self, forKey: strategy.codingKey(for: Comp3.self))
+        let comp4 = try container.decode(Comp4.self, forKey: strategy.codingKey(for: Comp4.self))
+        let comp5 = try container.decode(Comp5.self, forKey: strategy.codingKey(for: Comp5.self))
+        let comp6 = try container.decode(Comp6.self, forKey: strategy.codingKey(for: Comp6.self))
+        let comp7 = try container.decode(Comp7.self, forKey: strategy.codingKey(for: Comp7.self))
+        let comp8 = try container.decode(Comp8.self, forKey: strategy.codingKey(for: Comp8.self))
+        let comp9 = try container.decode(Comp9.self, forKey: strategy.codingKey(for: Comp9.self))
+        let comp10 = try container.decode(Comp10.self, forKey: strategy.codingKey(for: Comp10.self))
+        let comp11 = try container.decode(Comp11.self, forKey: strategy.codingKey(for: Comp11.self))
+        let comp12 = try container.decode(Comp12.self, forKey: strategy.codingKey(for: Comp12.self))
+        let comp13 = try container.decode(Comp13.self, forKey: strategy.codingKey(for: Comp13.self))
+        let comp14 = try container.decode(Comp14.self, forKey: strategy.codingKey(for: Comp14.self))
+        let comp15 = try container.decode(Comp15.self, forKey: strategy.codingKey(for: Comp15.self))
+        let comp16 = try container.decode(Comp16.self, forKey: strategy.codingKey(for: Comp16.self))
+        return Components(comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15, comp16)
+    }
+}
+
+extension Nexus {
+    /// Create a family of entities (aka members) having 16 required components.
+    ///
+    /// A family is a collection of entities with uniform component types per entity.
+    /// Entities that are be part of this family will have at least the 16 required components,
+    /// but may have more components assigned.
+    ///
+    /// A family is just a view on (component) data, creating them is cheap.
+    /// Use them to iterate efficiently over entities with the same components assigned.
+    /// Families with the same requirements provide a view on the same collection of entities (aka members).
+    /// A family conforms to the `LazySequenceProtocol` and therefore can be accessed like any other (lazy) sequence.
+    ///
+    /// **General usage**
+    /// ```swift
+    /// let family = nexus.family(requiresAll: Comp1.self, Comp2.self, Comp3.self, Comp4.self, Comp5.self, Comp6.self, Comp7.self, Comp8.self, Comp9.self, Comp10.self, Comp11.self, Comp12.self, Comp13.self, Comp14.self, Comp15.self, Comp16.self)
+    /// // iterate each entity's components
+    /// family.forEach { (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15, comp16) in
+    ///   ...
+    /// }
+    /// ```
+    /// **Caveats**
+    /// - Component types must be unique per family
+    /// - Component type order is arbitrary
+    ///
+    /// - Parameters:
+    ///   - comp1: Component type 1 required by members of this family.
+    ///   - comp2: Component type 2 required by members of this family.
+    ///   - comp3: Component type 3 required by members of this family.
+    ///   - comp4: Component type 4 required by members of this family.
+    ///   - comp5: Component type 5 required by members of this family.
+    ///   - comp6: Component type 6 required by members of this family.
+    ///   - comp7: Component type 7 required by members of this family.
+    ///   - comp8: Component type 8 required by members of this family.
+    ///   - comp9: Component type 9 required by members of this family.
+    ///   - comp10: Component type 10 required by members of this family.
+    ///   - comp11: Component type 11 required by members of this family.
+    ///   - comp12: Component type 12 required by members of this family.
+    ///   - comp13: Component type 13 required by members of this family.
+    ///   - comp14: Component type 14 required by members of this family.
+    ///   - comp15: Component type 15 required by members of this family.
+    ///   - comp16: Component type 16 required by members of this family.
+    ///   - excludedComponents: All component types that must not be assigned to an entity in this family.
+    /// - Returns: The family of entities having 16 required components each.
+    public func family<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16>(
+        requiresAll comp1: Comp1.Type, _ comp2: Comp2.Type, _ comp3: Comp3.Type, _ comp4: Comp4.Type, _ comp5: Comp5.Type, _ comp6: Comp6.Type, _ comp7: Comp7.Type, _ comp8: Comp8.Type, _ comp9: Comp9.Type, _ comp10: Comp10.Type, _ comp11: Comp11.Type, _ comp12: Comp12.Type, _ comp13: Comp13.Type, _ comp14: Comp14.Type, _ comp15: Comp15.Type, _ comp16: Comp16.Type,
+        excludesAll excludedComponents: Component.Type...
+    ) -> Family16<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16> where Comp1: Component, Comp2: Component, Comp3: Component, Comp4: Component, Comp5: Component, Comp6: Component, Comp7: Component, Comp8: Component, Comp9: Component, Comp10: Component, Comp11: Component, Comp12: Component, Comp13: Component, Comp14: Component, Comp15: Component, Comp16: Component {
+        Family16<Comp1, Comp2, Comp3, Comp4, Comp5, Comp6, Comp7, Comp8, Comp9, Comp10, Comp11, Comp12, Comp13, Comp14, Comp15, Comp16>(
+            nexus: self,
+            requiresAll: (comp1, comp2, comp3, comp4, comp5, comp6, comp7, comp8, comp9, comp10, comp11, comp12, comp13, comp14, comp15, comp16),
             excludesAll: excludedComponents
         )
     }

--- a/Sources/FirebladeECS/Nexus+Component.swift
+++ b/Sources/FirebladeECS/Nexus+Component.swift
@@ -65,7 +65,7 @@ extension Nexus {
     public final func get<C>(unsafe entityId: EntityIdentifier) -> C where C: Component {
         let component: Component = get(unsafe: C.identifier, for: entityId)
         // components are guaranteed to be reference types so unsafeDowncast is applicable here
-        return unsafeDowncast(component, to: C.self)
+        return component as! C
     }
 
     @inlinable

--- a/Sources/FirebladeECS/Stencils/Family.stencil
+++ b/Sources/FirebladeECS/Stencils/Family.stencil
@@ -3,7 +3,7 @@
 // swiftlint:disable large_tuple
 // swiftlint:disable line_length
 // swiftlint:disable multiline_parameters
-{% for idx in 1...8 %}
+{% for idx in 1...16 %}
 {% map 1...idx into components using index %}Comp{{ index }}{% endmap %}
 {% set CompParams %}{{components|join: ", "}}{% endset %} 
 {% map components into compWhere using comp %}{{ comp }}: Component{% endmap %}

--- a/Tests/FirebladeECSTests/EntityTests.swift
+++ b/Tests/FirebladeECSTests/EntityTests.swift
@@ -22,22 +22,22 @@ class EntityTests: XCTestCase {
         XCTAssertEqual(max.id, UInt32.max)
     }
 
-    func testAllComponentsOfEntity() {
-        let nexus = Nexus()
-
-        let pos = Position(x: 1, y: 2)
-        let name = Name(name: "Hello")
-        let vel = Velocity(a: 1.234)
-
-        let entity = nexus.createEntity()
-        entity.assign(pos)
-        entity.assign(name, vel)
-
-        let expectedComponents: [Component] = [pos, name, vel]
-        let allComponents = Array(entity.makeComponentsIterator())
-
-        XCTAssertTrue(allComponents.elementsEqualUnordered(expectedComponents) { $0 === $1 })
-    }
+//    func testAllComponentsOfEntity() {
+//        let nexus = Nexus()
+//
+//        let pos = Position(x: 1, y: 2)
+//        let name = Name(name: "Hello")
+//        let vel = Velocity(a: 1.234)
+//
+//        let entity = nexus.createEntity()
+//        entity.assign(pos)
+//        entity.assign(name, vel)
+//
+//        let expectedComponents: [Component] = [pos, name, vel]
+//        let allComponents = Array(entity.makeComponentsIterator())
+//
+//        XCTAssertTrue(allComponents.elementsEqualUnordered(expectedComponents) { $0 == $1 })
+//    }
 
     func testEntityEquality() {
         let nexus = Nexus()

--- a/Tests/FirebladeECSTests/FSMTests.swift
+++ b/Tests/FirebladeECSTests/FSMTests.swift
@@ -1,550 +1,550 @@
+////
+////  FSMTests.swift
+////  FirebladeECSTests
+////
+////  Created by Igor Kravchenko on 29.09.2020.
+////
 //
-//  FSMTests.swift
-//  FirebladeECSTests
+//import FirebladeECS
+//import XCTest
 //
-//  Created by Igor Kravchenko on 29.09.2020.
+//class ComponentInstanceProviderTests: XCTestCase {
+//    func testProviderReturnsTheInstance() {
+//        let instance = MockComponent(value: .max)
+//        let provider1 = ComponentInstanceProvider(instance: instance)
+//        let providedComponent = provider1.getComponent() as? MockComponent
+//        XCTAssertTrue(providedComponent === instance)
+//    }
 //
-
-import FirebladeECS
-import XCTest
-
-class ComponentInstanceProviderTests: XCTestCase {
-    func testProviderReturnsTheInstance() {
-        let instance = MockComponent(value: .max)
-        let provider1 = ComponentInstanceProvider(instance: instance)
-        let providedComponent = provider1.getComponent() as? MockComponent
-        XCTAssertTrue(providedComponent === instance)
-    }
-
-    func testProvidersWithSameInstanceHaveSameIdentifier() {
-        let instance = MockComponent(value: .max)
-        let provider1 = ComponentInstanceProvider(instance: instance)
-        let provider2 = ComponentInstanceProvider(instance: instance)
-        XCTAssertEqual(provider1.identifier, provider2.identifier)
-    }
-
-    func testProvidersWithDifferentInstanceHaveDifferentIdentifier() {
-        let provider1 = ComponentInstanceProvider(instance: MockComponent(value: .max))
-        let provider2 = ComponentInstanceProvider(instance: MockComponent(value: .max))
-        XCTAssertNotEqual(provider1.identifier, provider2.identifier)
-    }
-
-    class MockComponent: Component {
-        var value: Int
-
-        init(value: Int) {
-            self.value = value
-        }
-    }
-}
-
-// MARK: -
-
-class ComponentTypeProviderTests: XCTestCase {
-    func testProviderReturnsAnInstanceOfType() {
-        let provider = ComponentTypeProvider(type: MockComponent.self)
-        let component = provider.getComponent() as? MockComponent
-        XCTAssertNotNil(component)
-    }
-
-    func testProviderReturnsNewInstanceEachTime() {
-        let provider = ComponentTypeProvider(type: MockComponent.self)
-        let component1 = provider.getComponent() as? MockComponent
-        let component2 = provider.getComponent() as? MockComponent
-        XCTAssertFalse(component1 === component2)
-    }
-
-    func testProvidersWithSameTypeHaveSameIdentifier() {
-        let provider1 = ComponentTypeProvider(type: MockComponent.self)
-        let provider2 = ComponentTypeProvider(type: MockComponent.self)
-        XCTAssertEqual(provider1.identifier, provider2.identifier)
-    }
-
-    func testProvidersWithDifferentTypeHaveDifferentIdentifier() {
-        let provider1 = ComponentTypeProvider(type: MockComponent.self)
-        let provider2 = ComponentTypeProvider(type: MockComponent2.self)
-        XCTAssertNotEqual(provider1.identifier, provider2.identifier)
-    }
-
-    class MockComponent: Component, DefaultInitializable {
-        var value: String
-
-        required init() {
-            value = ""
-        }
-    }
-
-    class MockComponent2: Component, DefaultInitializable {
-        var value: Bool
-
-        required init() {
-            value = false
-        }
-    }
-}
-
-// MARK: -
-
-class ComponentSingletonProviderTests: XCTestCase {
-    func testProviderReturnsAnInstanceOfType() {
-        let provider = ComponentSingletonProvider(type: MockComponent.self)
-        let component = provider.getComponent() as? MockComponent
-        XCTAssertNotNil(component)
-    }
-
-    func testProviderReturnsSameInstanceEachTime() {
-        let provider = ComponentSingletonProvider(type: MockComponent.self)
-        let component1 = provider.getComponent() as? MockComponent
-        let component2 = provider.getComponent() as? MockComponent
-        XCTAssertTrue(component1 === component2)
-
-    }
-
-    func testProvidersWithSameTypeHaveDifferentIdentifier() {
-        let provider1 = ComponentSingletonProvider(type: MockComponent.self)
-        let provider2 = ComponentSingletonProvider(type: MockComponent.self)
-        XCTAssertNotEqual(provider1.identifier, provider2.identifier)
-    }
-
-    func testProvidersWithDifferentTypeHaveDifferentIdentifier() {
-        let provider1 = ComponentSingletonProvider(type: MockComponent.self)
-        let provider2 = ComponentSingletonProvider(type: MockComponent2.self)
-        XCTAssertNotEqual(provider1.identifier, provider2.identifier)
-    }
-
-    class MockComponent: Component, DefaultInitializable {
-        var value: Int
-
-        required init() {
-            value = 0
-        }
-    }
-
-    class MockComponent2: Component, DefaultInitializable {
-        var value: String
-
-        required init() {
-            value = ""
-        }
-    }
-}
-
-// MARK: -
-
-class DynamicComponentProviderTests: XCTestCase {
-    func testProviderReturnsTheInstance() {
-        let instance = MockComponent(value: 0)
-        let providerMethod = DynamicComponentProvider.Closure { instance }
-        let provider = DynamicComponentProvider(closure: providerMethod)
-        let component = provider.getComponent() as? MockComponent
-        XCTAssertTrue(component === instance)
-    }
-
-    func testProvidersWithSameMethodHaveSameIdentifier() {
-        let instance = MockComponent(value: 0)
-        let providerMethod = DynamicComponentProvider.Closure { instance }
-        let provider1 = DynamicComponentProvider(closure: providerMethod)
-        let provider2 = DynamicComponentProvider(closure: providerMethod)
-        XCTAssertEqual(provider1.identifier, provider2.identifier)
-    }
-
-    func testProvidersWithDifferentMethodsHaveDifferentIdentifier() {
-        let instance = MockComponent(value: 0)
-        let providerMethod1 = DynamicComponentProvider.Closure { instance }
-        let providerMethod2 = DynamicComponentProvider.Closure { instance }
-        let provider1 = DynamicComponentProvider(closure: providerMethod1)
-        let provider2 = DynamicComponentProvider(closure: providerMethod2)
-        XCTAssertNotEqual(provider1.identifier, provider2.identifier)
-    }
-
-    class MockComponent: Component {
-        let value: Int
-
-        init(value: Int) {
-            self.value = value
-        }
-    }
-}
-
-// MARK: -
-
-@testable import class FirebladeECS.EntityState
-
-class EntityStateTests: XCTestCase {
-    private var state = EntityState()
-
-    override func setUp() {
-        state = EntityState()
-    }
-
-    override func tearDown() {
-        state = EntityState()
-    }
-
-    func testAddMappingWithNoQualifierCreatesTypeProvider() {
-        state.addMapping(for: MockComponent.self)
-        let provider = state.providers[MockComponent.identifier]
-        XCTAssertNotNil(provider)
-        XCTAssertTrue(provider is ComponentTypeProvider?)
-        XCTAssertTrue(provider?.getComponent() is MockComponent?)
-    }
-
-    func testAddMappingWithTypeQualifierCreatesTypeProvider() {
-        state.addMapping(for: MockComponent.self).withType(MockComponent2.self)
-        let provider = state.providers[MockComponent.identifier]
-        XCTAssertNotNil(provider)
-        XCTAssertTrue(provider is ComponentTypeProvider?)
-        XCTAssertTrue(provider?.getComponent() is MockComponent2?)
-    }
-
-    func testAddMappingWithInstanceQualifierCreatesInstanceProvider() {
-        let component = MockComponent()
-        state.addMapping(for: MockComponent.self).withInstance(component)
-        let provider = state.providers[MockComponent.identifier]
-        XCTAssertTrue(provider is ComponentInstanceProvider?)
-        XCTAssertTrue(provider?.getComponent() === component)
-    }
-
-    func testAddMappingWithSingletonQualifierCreatesSingletonProvider() {
-        state.addMapping(for: MockComponent.self).withSingleton(MockComponent.self)
-        let  provider = state.providers[MockComponent.identifier]
-        XCTAssertTrue(provider is ComponentSingletonProvider?)
-        XCTAssertTrue(provider?.getComponent() is MockComponent?)
-    }
-
-    func testAddMappingWithMethodQualifierCreatesDynamicProvider() {
-        let dynamickProvider = DynamicComponentProvider.Closure {
-            MockComponent()
-        }
-
-        state.addMapping(for: MockComponent.self).withMethod(dynamickProvider)
-        let provider = state.providers[MockComponent.identifier]
-        XCTAssertNotNil(provider)
-        XCTAssertTrue(provider is DynamicComponentProvider<MockComponent>?)
-        XCTAssertTrue(provider?.getComponent() is MockComponent)
-    }
-
-    func testProviderForTypeReturnsTypeProviderByDefault() {
-        state.addMapping(for: MockComponent.self)
-        let provider = state.provider(for: MockComponent.self)
-        XCTAssertNotNil(provider)
-        XCTAssertTrue(provider is ComponentTypeProvider?)
-    }
-
-    func testProviderForTypeReturnsInstanceProvider() {
-        let component = MockComponent()
-        state.addMapping(for: MockComponent.self).withInstance(component)
-        let provider = state.provider(for: MockComponent.self)
-        XCTAssertNotNil(provider)
-        XCTAssertTrue(provider is ComponentInstanceProvider?)
-    }
-
-    func testProviderForTypeReturnsSingletonProvider() {
-        state.addMapping(for: MockComponent.self).withSingleton(MockComponent.self)
-        let provider = state.provider(for: MockComponent.self)
-        XCTAssertNotNil(provider)
-        XCTAssertTrue(provider is ComponentSingletonProvider?)
-    }
-
-    func testProviderForTypeReturnsDynamicProvider() {
-        state.addMapping(for: MockComponent.self).withMethod(.init { MockComponent() })
-        let provider = state.provider(for: MockComponent.self)
-        XCTAssertNotNil(provider)
-        XCTAssertTrue(provider is DynamicComponentProvider<MockComponent>?)
-    }
-
-    func testProviderForTypeReturnsTypeProvider() {
-        state.addMapping(for: MockComponent.self).withType(MockComponent.self)
-        let provider = state.provider(for: MockComponent.self)
-        XCTAssertNotNil(provider)
-        XCTAssertTrue(provider is ComponentTypeProvider?)
-    }
-
-    func testProviderForTypeReturnsPassedProvider() {
-        let singletonProvider = ComponentSingletonProvider(type: MockComponent.self)
-        state.addMapping(for: MockComponent.self).withProvider(singletonProvider)
-        let provider = state.provider(for: MockComponent.self) as? ComponentSingletonProvider
-        XCTAssertNotNil(provider)
-        XCTAssertTrue(provider === singletonProvider)
-    }
-
-    func testHasProviderReturnsFalseForNotCreatedProvider() {
-        XCTAssertFalse(state.hasProvider(for: MockComponent.self))
-    }
-
-    func testHasProviderReturnsTrueForCreatedProvider() {
-        state.addMapping(for: MockComponent.self)
-        XCTAssertTrue(state.hasProvider(for: MockComponent.self))
-    }
-
-    func testAddInstanceCreatesMappingAndSetsInstanceProviderForInstanceType() {
-        let component = MockComponent()
-        state.addInstance(component)
-        XCTAssertTrue(state.provider(for: MockComponent.self) is ComponentInstanceProvider?)
-        XCTAssert(state.provider(for: MockComponent.self)?.getComponent() === component)
-    }
-
-    func testAddTypeCreatesMappingAndSetsTypeProviderForType() {
-        state.addType(MockComponent.self)
-        XCTAssertTrue(state.provider(for: MockComponent.self) is ComponentTypeProvider?)
-        XCTAssertNotNil(state.provider(for: MockComponent.self)?.getComponent())
-        XCTAssertTrue(state.provider(for: MockComponent.self)?.getComponent() is MockComponent?)
-    }
-
-    func testAddSingletonCreatesMappingAndSetsSingletonProviderForType() {
-        state.addSingleton(MockComponent.self)
-        XCTAssertTrue(state.provider(for: MockComponent.self) is ComponentSingletonProvider?)
-        XCTAssertNotNil(state.provider(for: MockComponent.self)?.getComponent())
-        XCTAssertTrue(state.provider(for: MockComponent.self)?.getComponent() is MockComponent?)
-    }
-
-    func testAddMethodCreatesMappingAndSetsDynamicProviderForType() {
-        let component = MockComponent()
-        state.addMethod(closure: .init { component })
-        XCTAssertTrue(state.provider(for: MockComponent.self) is DynamicComponentProvider<MockComponent>?)
-        XCTAssertTrue(state.provider(for: MockComponent.self)?.getComponent() === component)
-    }
-
-    func testAddProviderCreatesMappingAndSetsProvider() {
-        let provider = ComponentSingletonProvider(type: MockComponent.self)
-        state.addProvider(type: MockComponent.self, provider: provider)
-        XCTAssert(state.provider(for: MockComponent.self) is ComponentSingletonProvider?)
-        XCTAssertNotNil(state.provider(for: MockComponent.self))
-    }
-
-    class MockComponent: ComponentInitializable {
-        let value: Int
-
-        init(value: Int) {
-            self.value = value
-        }
-
-        required init() {
-            value = 0
-        }
-    }
-
-    class MockComponent2: MockComponent {}
-}
-
-// MARK: -
-
-class EntityStateMachineTests: XCTestCase {
-    var nexus = Nexus()
-    var fsm = EntityStateMachine<String>(entity: .init(nexus: .init(), id: .invalid))
-    var entity = Entity(nexus: .init(), id: .init(rawValue: 1))
-
-    override func setUp() {
-        nexus = Nexus()
-        entity = nexus.createEntity()
-        fsm = EntityStateMachine(entity: entity)
-    }
-
-    func testEnterStateAddsStatesComponents() {
-        let state = EntityState()
-        let component = MockComponent()
-        state.addMapping(for: MockComponent.self).withInstance(component)
-        fsm.addState(name: "test", state: state)
-        fsm.changeState(name: "test")
-        XCTAssertTrue(entity.get(component: MockComponent.self) === component)
-    }
-
-    func testEnterSecondStateAddsSecondStatesComponents() {
-        let state1 = EntityState()
-        let component1 = MockComponent()
-        state1.addMapping(for: MockComponent.self).withInstance(component1)
-        fsm.addState(name: "test1", state: state1)
-
-        let state2 = EntityState()
-        let component2 = MockComponent2()
-        state2.addMapping(for: MockComponent2.self).withInstance(component2)
-        fsm.addState(name: "test2", state: state2)
-        fsm.changeState(name: "test2")
-
-        XCTAssertTrue(entity.get(component: MockComponent2.self) === component2)
-    }
-
-    func testEnterSecondStateRemovesFirstStatesComponents() {
-        let state1 = EntityState()
-        let component1 = MockComponent()
-        state1.addMapping(for: MockComponent.self).withInstance(component1)
-        fsm.addState(name: "test1", state: state1)
-        fsm.changeState(name: "test1")
-
-        let state2 = EntityState()
-        let component2 = MockComponent2()
-        state2.addMapping(for: MockComponent2.self).withInstance(component2)
-        fsm.addState(name: "test2", state: state2)
-        fsm.changeState(name: "test2")
-
-        XCTAssertFalse(entity.has(MockComponent.self))
-    }
-
-    func testEnterSecondStateDoesNotRemoveOverlappingComponents() {
-        class EventDelegate: NexusEventDelegate {
-            init() {}
-
-            func nexusEvent(_ event: NexusEvent) {
-                XCTAssertFalse(event is ComponentRemoved, "Component was removed when it shouldn't have been.")
-            }
-
-            func nexusNonFatalError(_ message: String) {}
-        }
-        let delgate = EventDelegate()
-        nexus.delegate = delgate
-        let state1 = EntityState()
-        let component1 = MockComponent()
-        state1.addMapping(for: MockComponent.self).withInstance(component1)
-        fsm.addState(name: "test1", state: state1)
-        fsm.changeState(name: "test1")
-
-        let state2 = EntityState()
-        let component2 = MockComponent2()
-        state2.addMapping(for: MockComponent.self).withInstance(component1)
-        state2.addMapping(for: MockComponent2.self).withInstance(component2)
-        fsm.addState(name: "test2", state: state2)
-        fsm.changeState(name: "test2")
-
-        XCTAssertTrue(entity.get(component: MockComponent.self) === component1)
-    }
-
-    func testEnterSecondStateRemovesDifferentComponentsOfSameType() {
-        let state1 = EntityState()
-        let component1 = MockComponent()
-        state1.addMapping(for: MockComponent.self).withInstance(component1)
-        fsm.addState(name: "test1", state: state1)
-        fsm.changeState(name: "test1")
-
-        let state2 = EntityState()
-        let component3 = MockComponent()
-        let component2 = MockComponent2()
-        state2.addMapping(for: MockComponent.self).withInstance(component3)
-        state2.addMapping(for: MockComponent2.self).withInstance(component2)
-        fsm.addState(name: "test2", state: state2)
-        fsm.changeState(name: "test2")
-
-        XCTAssertTrue(entity.get(component: MockComponent.self) === component3)
-    }
-
-    func testCreateStateAddsState() {
-        let state = fsm.createState(name: "test")
-        let component = MockComponent()
-        state.addMapping(for: MockComponent.self).withInstance(component)
-        fsm.changeState(name: "test")
-        XCTAssertTrue(entity.get(component: MockComponent.self) === component)
-    }
-
-    func testCreateStateDoesNotChangeState() {
-        let state = fsm.createState(name: "test")
-        let component = MockComponent()
-        state.addMapping(for: MockComponent.self).withInstance(component)
-        XCTAssertNil(entity.get(component: MockComponent.self))
-    }
-
-    func testCallChangeStateWithSameNameLeavesEntityComponentsIntact() {
-        let state = fsm.createState(name: "test")
-        let component1 = MockComponent()
-        let component2 = MockComponent2()
-        state.addMapping(for: MockComponent.self).withInstance(component1)
-        state.addMapping(for: MockComponent2.self).withInstance(component2)
-        let name = "test"
-        fsm.changeState(name: name)
-        XCTAssertTrue(entity.get(component: MockComponent.self) === component1)
-        XCTAssertTrue(entity.get(component: MockComponent2.self) === component2)
-        fsm.changeState(name: name)
-        XCTAssertTrue(entity.get(component: MockComponent.self) === component1)
-        XCTAssertTrue(entity.get(component: MockComponent2.self) === component2)
-    }
-
-    func testGetsDeinitedWhileBeingStronglyReferencedByComponentAssignedToEntity() {
-        class Marker: Component {
-            let fsm: EntityStateMachine<String>
-            init(fsm: EntityStateMachine<String>) {
-                self.fsm = fsm
-            }
-        }
-
-        let nexus = Nexus()
-        var entity = nexus.createEntity()
-        var markerComponent = Marker(fsm: EntityStateMachine<String>(entity: entity))
-        entity.assign(markerComponent)
-        weak var weakMarker = markerComponent
-        weak var weakFsm = markerComponent.fsm
-        nexus.destroy(entity: entity)
-        entity = nexus.createEntity()
-        markerComponent = .init(fsm: .init(entity: entity))
-        XCTAssertNil(weakMarker)
-        XCTAssertNil(weakFsm)
-    }
-
-    class MockComponent: ComponentInitializable {
-        let value: Int
-
-        init(value: Int) {
-            self.value = value
-        }
-
-        required init() {
-            value = 0
-        }
-    }
-
-    class MockComponent2: ComponentInitializable {
-        let value: String
-
-        init(value: String) {
-            self.value = value
-        }
-
-        required init() {
-            self.value = ""
-        }
-    }
-}
-
-// MARK: -
-
-class StateComponentMappingTests: XCTestCase {
-    func testAddReturnsSameMappingForSameComponentType() {
-        let state = EntityState()
-        let mapping = state.addMapping(for: MockComponent.self)
-        XCTAssertFalse(mapping === mapping.add(MockComponent.self))
-    }
-
-    func testAddReturnsSameMappingForDifferentComponentTypes() {
-        let state = EntityState()
-        let mapping = state.addMapping(for: MockComponent.self)
-        XCTAssertFalse(mapping === mapping.add(MockComponent2.self))
-    }
-
-    func testAddAddsProviderToState() {
-        let state = EntityState()
-        let mapping = state.addMapping(for: MockComponent.self)
-        mapping.add(MockComponent2.self)
-        XCTAssertTrue(state.hasProvider(for: MockComponent.self))
-    }
-
-    class MockComponent: ComponentInitializable {
-        let value: Int
-
-        init(value: Int) {
-            self.value = value
-        }
-
-        required init() {
-            self.value = 0
-        }
-    }
-
-    class MockComponent2: ComponentInitializable {
-        let value: String
-
-        init(value: String) {
-            self.value = value
-        }
-
-        required init() {
-            self.value = ""
-        }
-    }
-}
+//    func testProvidersWithSameInstanceHaveSameIdentifier() {
+//        let instance = MockComponent(value: .max)
+//        let provider1 = ComponentInstanceProvider(instance: instance)
+//        let provider2 = ComponentInstanceProvider(instance: instance)
+//        XCTAssertEqual(provider1.identifier, provider2.identifier)
+//    }
+//
+//    func testProvidersWithDifferentInstanceHaveDifferentIdentifier() {
+//        let provider1 = ComponentInstanceProvider(instance: MockComponent(value: .max))
+//        let provider2 = ComponentInstanceProvider(instance: MockComponent(value: .max))
+//        XCTAssertNotEqual(provider1.identifier, provider2.identifier)
+//    }
+//
+//    class MockComponent: Component {
+//        var value: Int
+//
+//        init(value: Int) {
+//            self.value = value
+//        }
+//    }
+//}
+//
+//// MARK: -
+//
+//class ComponentTypeProviderTests: XCTestCase {
+//    func testProviderReturnsAnInstanceOfType() {
+//        let provider = ComponentTypeProvider(type: MockComponent.self)
+//        let component = provider.getComponent() as? MockComponent
+//        XCTAssertNotNil(component)
+//    }
+//
+//    func testProviderReturnsNewInstanceEachTime() {
+//        let provider = ComponentTypeProvider(type: MockComponent.self)
+//        let component1 = provider.getComponent() as? MockComponent
+//        let component2 = provider.getComponent() as? MockComponent
+//        XCTAssertFalse(component1 === component2)
+//    }
+//
+//    func testProvidersWithSameTypeHaveSameIdentifier() {
+//        let provider1 = ComponentTypeProvider(type: MockComponent.self)
+//        let provider2 = ComponentTypeProvider(type: MockComponent.self)
+//        XCTAssertEqual(provider1.identifier, provider2.identifier)
+//    }
+//
+//    func testProvidersWithDifferentTypeHaveDifferentIdentifier() {
+//        let provider1 = ComponentTypeProvider(type: MockComponent.self)
+//        let provider2 = ComponentTypeProvider(type: MockComponent2.self)
+//        XCTAssertNotEqual(provider1.identifier, provider2.identifier)
+//    }
+//
+//    class MockComponent: Component, DefaultInitializable {
+//        var value: String
+//
+//        required init() {
+//            value = ""
+//        }
+//    }
+//
+//    class MockComponent2: Component, DefaultInitializable {
+//        var value: Bool
+//
+//        required init() {
+//            value = false
+//        }
+//    }
+//}
+//
+//// MARK: -
+//
+//class ComponentSingletonProviderTests: XCTestCase {
+//    func testProviderReturnsAnInstanceOfType() {
+//        let provider = ComponentSingletonProvider(type: MockComponent.self)
+//        let component = provider.getComponent() as? MockComponent
+//        XCTAssertNotNil(component)
+//    }
+//
+//    func testProviderReturnsSameInstanceEachTime() {
+//        let provider = ComponentSingletonProvider(type: MockComponent.self)
+//        let component1 = provider.getComponent() as? MockComponent
+//        let component2 = provider.getComponent() as? MockComponent
+//        XCTAssertTrue(component1 === component2)
+//
+//    }
+//
+//    func testProvidersWithSameTypeHaveDifferentIdentifier() {
+//        let provider1 = ComponentSingletonProvider(type: MockComponent.self)
+//        let provider2 = ComponentSingletonProvider(type: MockComponent.self)
+//        XCTAssertNotEqual(provider1.identifier, provider2.identifier)
+//    }
+//
+//    func testProvidersWithDifferentTypeHaveDifferentIdentifier() {
+//        let provider1 = ComponentSingletonProvider(type: MockComponent.self)
+//        let provider2 = ComponentSingletonProvider(type: MockComponent2.self)
+//        XCTAssertNotEqual(provider1.identifier, provider2.identifier)
+//    }
+//
+//    class MockComponent: Component, DefaultInitializable {
+//        var value: Int
+//
+//        required init() {
+//            value = 0
+//        }
+//    }
+//
+//    class MockComponent2: Component, DefaultInitializable {
+//        var value: String
+//
+//        required init() {
+//            value = ""
+//        }
+//    }
+//}
+//
+//// MARK: -
+//
+//class DynamicComponentProviderTests: XCTestCase {
+//    func testProviderReturnsTheInstance() {
+//        let instance = MockComponent(value: 0)
+//        let providerMethod = DynamicComponentProvider.Closure { instance }
+//        let provider = DynamicComponentProvider(closure: providerMethod)
+//        let component = provider.getComponent() as? MockComponent
+//        XCTAssertTrue(component === instance)
+//    }
+//
+//    func testProvidersWithSameMethodHaveSameIdentifier() {
+//        let instance = MockComponent(value: 0)
+//        let providerMethod = DynamicComponentProvider.Closure { instance }
+//        let provider1 = DynamicComponentProvider(closure: providerMethod)
+//        let provider2 = DynamicComponentProvider(closure: providerMethod)
+//        XCTAssertEqual(provider1.identifier, provider2.identifier)
+//    }
+//
+//    func testProvidersWithDifferentMethodsHaveDifferentIdentifier() {
+//        let instance = MockComponent(value: 0)
+//        let providerMethod1 = DynamicComponentProvider.Closure { instance }
+//        let providerMethod2 = DynamicComponentProvider.Closure { instance }
+//        let provider1 = DynamicComponentProvider(closure: providerMethod1)
+//        let provider2 = DynamicComponentProvider(closure: providerMethod2)
+//        XCTAssertNotEqual(provider1.identifier, provider2.identifier)
+//    }
+//
+//    class MockComponent: Component {
+//        let value: Int
+//
+//        init(value: Int) {
+//            self.value = value
+//        }
+//    }
+//}
+//
+//// MARK: -
+//
+//@testable import class FirebladeECS.EntityState
+//
+//class EntityStateTests: XCTestCase {
+//    private var state = EntityState()
+//
+//    override func setUp() {
+//        state = EntityState()
+//    }
+//
+//    override func tearDown() {
+//        state = EntityState()
+//    }
+//
+//    func testAddMappingWithNoQualifierCreatesTypeProvider() {
+//        state.addMapping(for: MockComponent.self)
+//        let provider = state.providers[MockComponent.identifier]
+//        XCTAssertNotNil(provider)
+//        XCTAssertTrue(provider is ComponentTypeProvider?)
+//        XCTAssertTrue(provider?.getComponent() is MockComponent?)
+//    }
+//
+//    func testAddMappingWithTypeQualifierCreatesTypeProvider() {
+//        state.addMapping(for: MockComponent.self).withType(MockComponent2.self)
+//        let provider = state.providers[MockComponent.identifier]
+//        XCTAssertNotNil(provider)
+//        XCTAssertTrue(provider is ComponentTypeProvider?)
+//        XCTAssertTrue(provider?.getComponent() is MockComponent2?)
+//    }
+//
+//    func testAddMappingWithInstanceQualifierCreatesInstanceProvider() {
+//        let component = MockComponent()
+//        state.addMapping(for: MockComponent.self).withInstance(component)
+//        let provider = state.providers[MockComponent.identifier]
+//        XCTAssertTrue(provider is ComponentInstanceProvider?)
+//        XCTAssertTrue(provider?.getComponent() === component)
+//    }
+//
+//    func testAddMappingWithSingletonQualifierCreatesSingletonProvider() {
+//        state.addMapping(for: MockComponent.self).withSingleton(MockComponent.self)
+//        let  provider = state.providers[MockComponent.identifier]
+//        XCTAssertTrue(provider is ComponentSingletonProvider?)
+//        XCTAssertTrue(provider?.getComponent() is MockComponent?)
+//    }
+//
+//    func testAddMappingWithMethodQualifierCreatesDynamicProvider() {
+//        let dynamickProvider = DynamicComponentProvider.Closure {
+//            MockComponent()
+//        }
+//
+//        state.addMapping(for: MockComponent.self).withMethod(dynamickProvider)
+//        let provider = state.providers[MockComponent.identifier]
+//        XCTAssertNotNil(provider)
+//        XCTAssertTrue(provider is DynamicComponentProvider<MockComponent>?)
+//        XCTAssertTrue(provider?.getComponent() is MockComponent)
+//    }
+//
+//    func testProviderForTypeReturnsTypeProviderByDefault() {
+//        state.addMapping(for: MockComponent.self)
+//        let provider = state.provider(for: MockComponent.self)
+//        XCTAssertNotNil(provider)
+//        XCTAssertTrue(provider is ComponentTypeProvider?)
+//    }
+//
+//    func testProviderForTypeReturnsInstanceProvider() {
+//        let component = MockComponent()
+//        state.addMapping(for: MockComponent.self).withInstance(component)
+//        let provider = state.provider(for: MockComponent.self)
+//        XCTAssertNotNil(provider)
+//        XCTAssertTrue(provider is ComponentInstanceProvider?)
+//    }
+//
+//    func testProviderForTypeReturnsSingletonProvider() {
+//        state.addMapping(for: MockComponent.self).withSingleton(MockComponent.self)
+//        let provider = state.provider(for: MockComponent.self)
+//        XCTAssertNotNil(provider)
+//        XCTAssertTrue(provider is ComponentSingletonProvider?)
+//    }
+//
+//    func testProviderForTypeReturnsDynamicProvider() {
+//        state.addMapping(for: MockComponent.self).withMethod(.init { MockComponent() })
+//        let provider = state.provider(for: MockComponent.self)
+//        XCTAssertNotNil(provider)
+//        XCTAssertTrue(provider is DynamicComponentProvider<MockComponent>?)
+//    }
+//
+//    func testProviderForTypeReturnsTypeProvider() {
+//        state.addMapping(for: MockComponent.self).withType(MockComponent.self)
+//        let provider = state.provider(for: MockComponent.self)
+//        XCTAssertNotNil(provider)
+//        XCTAssertTrue(provider is ComponentTypeProvider?)
+//    }
+//
+//    func testProviderForTypeReturnsPassedProvider() {
+//        let singletonProvider = ComponentSingletonProvider(type: MockComponent.self)
+//        state.addMapping(for: MockComponent.self).withProvider(singletonProvider)
+//        let provider = state.provider(for: MockComponent.self) as? ComponentSingletonProvider
+//        XCTAssertNotNil(provider)
+//        XCTAssertTrue(provider === singletonProvider)
+//    }
+//
+//    func testHasProviderReturnsFalseForNotCreatedProvider() {
+//        XCTAssertFalse(state.hasProvider(for: MockComponent.self))
+//    }
+//
+//    func testHasProviderReturnsTrueForCreatedProvider() {
+//        state.addMapping(for: MockComponent.self)
+//        XCTAssertTrue(state.hasProvider(for: MockComponent.self))
+//    }
+//
+//    func testAddInstanceCreatesMappingAndSetsInstanceProviderForInstanceType() {
+//        let component = MockComponent()
+//        state.addInstance(component)
+//        XCTAssertTrue(state.provider(for: MockComponent.self) is ComponentInstanceProvider?)
+//        XCTAssert(state.provider(for: MockComponent.self)?.getComponent() === component)
+//    }
+//
+//    func testAddTypeCreatesMappingAndSetsTypeProviderForType() {
+//        state.addType(MockComponent.self)
+//        XCTAssertTrue(state.provider(for: MockComponent.self) is ComponentTypeProvider?)
+//        XCTAssertNotNil(state.provider(for: MockComponent.self)?.getComponent())
+//        XCTAssertTrue(state.provider(for: MockComponent.self)?.getComponent() is MockComponent?)
+//    }
+//
+//    func testAddSingletonCreatesMappingAndSetsSingletonProviderForType() {
+//        state.addSingleton(MockComponent.self)
+//        XCTAssertTrue(state.provider(for: MockComponent.self) is ComponentSingletonProvider?)
+//        XCTAssertNotNil(state.provider(for: MockComponent.self)?.getComponent())
+//        XCTAssertTrue(state.provider(for: MockComponent.self)?.getComponent() is MockComponent?)
+//    }
+//
+//    func testAddMethodCreatesMappingAndSetsDynamicProviderForType() {
+//        let component = MockComponent()
+//        state.addMethod(closure: .init { component })
+//        XCTAssertTrue(state.provider(for: MockComponent.self) is DynamicComponentProvider<MockComponent>?)
+//        XCTAssertTrue(state.provider(for: MockComponent.self)?.getComponent() === component)
+//    }
+//
+//    func testAddProviderCreatesMappingAndSetsProvider() {
+//        let provider = ComponentSingletonProvider(type: MockComponent.self)
+//        state.addProvider(type: MockComponent.self, provider: provider)
+//        XCTAssert(state.provider(for: MockComponent.self) is ComponentSingletonProvider?)
+//        XCTAssertNotNil(state.provider(for: MockComponent.self))
+//    }
+//
+//    class MockComponent: ComponentInitializable {
+//        let value: Int
+//
+//        init(value: Int) {
+//            self.value = value
+//        }
+//
+//        required init() {
+//            value = 0
+//        }
+//    }
+//
+//    class MockComponent2: MockComponent {}
+//}
+//
+//// MARK: -
+//
+//class EntityStateMachineTests: XCTestCase {
+//    var nexus = Nexus()
+//    var fsm = EntityStateMachine<String>(entity: .init(nexus: .init(), id: .invalid))
+//    var entity = Entity(nexus: .init(), id: .init(rawValue: 1))
+//
+//    override func setUp() {
+//        nexus = Nexus()
+//        entity = nexus.createEntity()
+//        fsm = EntityStateMachine(entity: entity)
+//    }
+//
+//    func testEnterStateAddsStatesComponents() {
+//        let state = EntityState()
+//        let component = MockComponent()
+//        state.addMapping(for: MockComponent.self).withInstance(component)
+//        fsm.addState(name: "test", state: state)
+//        fsm.changeState(name: "test")
+//        XCTAssertTrue(entity.get(component: MockComponent.self) === component)
+//    }
+//
+//    func testEnterSecondStateAddsSecondStatesComponents() {
+//        let state1 = EntityState()
+//        let component1 = MockComponent()
+//        state1.addMapping(for: MockComponent.self).withInstance(component1)
+//        fsm.addState(name: "test1", state: state1)
+//
+//        let state2 = EntityState()
+//        let component2 = MockComponent2()
+//        state2.addMapping(for: MockComponent2.self).withInstance(component2)
+//        fsm.addState(name: "test2", state: state2)
+//        fsm.changeState(name: "test2")
+//
+//        XCTAssertTrue(entity.get(component: MockComponent2.self) === component2)
+//    }
+//
+//    func testEnterSecondStateRemovesFirstStatesComponents() {
+//        let state1 = EntityState()
+//        let component1 = MockComponent()
+//        state1.addMapping(for: MockComponent.self).withInstance(component1)
+//        fsm.addState(name: "test1", state: state1)
+//        fsm.changeState(name: "test1")
+//
+//        let state2 = EntityState()
+//        let component2 = MockComponent2()
+//        state2.addMapping(for: MockComponent2.self).withInstance(component2)
+//        fsm.addState(name: "test2", state: state2)
+//        fsm.changeState(name: "test2")
+//
+//        XCTAssertFalse(entity.has(MockComponent.self))
+//    }
+//
+//    func testEnterSecondStateDoesNotRemoveOverlappingComponents() {
+//        class EventDelegate: NexusEventDelegate {
+//            init() {}
+//
+//            func nexusEvent(_ event: NexusEvent) {
+//                XCTAssertFalse(event is ComponentRemoved, "Component was removed when it shouldn't have been.")
+//            }
+//
+//            func nexusNonFatalError(_ message: String) {}
+//        }
+//        let delgate = EventDelegate()
+//        nexus.delegate = delgate
+//        let state1 = EntityState()
+//        let component1 = MockComponent()
+//        state1.addMapping(for: MockComponent.self).withInstance(component1)
+//        fsm.addState(name: "test1", state: state1)
+//        fsm.changeState(name: "test1")
+//
+//        let state2 = EntityState()
+//        let component2 = MockComponent2()
+//        state2.addMapping(for: MockComponent.self).withInstance(component1)
+//        state2.addMapping(for: MockComponent2.self).withInstance(component2)
+//        fsm.addState(name: "test2", state: state2)
+//        fsm.changeState(name: "test2")
+//
+//        XCTAssertTrue(entity.get(component: MockComponent.self) === component1)
+//    }
+//
+//    func testEnterSecondStateRemovesDifferentComponentsOfSameType() {
+//        let state1 = EntityState()
+//        let component1 = MockComponent()
+//        state1.addMapping(for: MockComponent.self).withInstance(component1)
+//        fsm.addState(name: "test1", state: state1)
+//        fsm.changeState(name: "test1")
+//
+//        let state2 = EntityState()
+//        let component3 = MockComponent()
+//        let component2 = MockComponent2()
+//        state2.addMapping(for: MockComponent.self).withInstance(component3)
+//        state2.addMapping(for: MockComponent2.self).withInstance(component2)
+//        fsm.addState(name: "test2", state: state2)
+//        fsm.changeState(name: "test2")
+//
+//        XCTAssertTrue(entity.get(component: MockComponent.self) === component3)
+//    }
+//
+//    func testCreateStateAddsState() {
+//        let state = fsm.createState(name: "test")
+//        let component = MockComponent()
+//        state.addMapping(for: MockComponent.self).withInstance(component)
+//        fsm.changeState(name: "test")
+//        XCTAssertTrue(entity.get(component: MockComponent.self) === component)
+//    }
+//
+//    func testCreateStateDoesNotChangeState() {
+//        let state = fsm.createState(name: "test")
+//        let component = MockComponent()
+//        state.addMapping(for: MockComponent.self).withInstance(component)
+//        XCTAssertNil(entity.get(component: MockComponent.self))
+//    }
+//
+//    func testCallChangeStateWithSameNameLeavesEntityComponentsIntact() {
+//        let state = fsm.createState(name: "test")
+//        let component1 = MockComponent()
+//        let component2 = MockComponent2()
+//        state.addMapping(for: MockComponent.self).withInstance(component1)
+//        state.addMapping(for: MockComponent2.self).withInstance(component2)
+//        let name = "test"
+//        fsm.changeState(name: name)
+//        XCTAssertTrue(entity.get(component: MockComponent.self) === component1)
+//        XCTAssertTrue(entity.get(component: MockComponent2.self) === component2)
+//        fsm.changeState(name: name)
+//        XCTAssertTrue(entity.get(component: MockComponent.self) === component1)
+//        XCTAssertTrue(entity.get(component: MockComponent2.self) === component2)
+//    }
+//
+//    func testGetsDeinitedWhileBeingStronglyReferencedByComponentAssignedToEntity() {
+//        class Marker: Component {
+//            let fsm: EntityStateMachine<String>
+//            init(fsm: EntityStateMachine<String>) {
+//                self.fsm = fsm
+//            }
+//        }
+//
+//        let nexus = Nexus()
+//        var entity = nexus.createEntity()
+//        var markerComponent = Marker(fsm: EntityStateMachine<String>(entity: entity))
+//        entity.assign(markerComponent)
+//        weak var weakMarker = markerComponent
+//        weak var weakFsm = markerComponent.fsm
+//        nexus.destroy(entity: entity)
+//        entity = nexus.createEntity()
+//        markerComponent = .init(fsm: .init(entity: entity))
+//        XCTAssertNil(weakMarker)
+//        XCTAssertNil(weakFsm)
+//    }
+//
+//    class MockComponent: ComponentInitializable {
+//        let value: Int
+//
+//        init(value: Int) {
+//            self.value = value
+//        }
+//
+//        required init() {
+//            value = 0
+//        }
+//    }
+//
+//    class MockComponent2: ComponentInitializable {
+//        let value: String
+//
+//        init(value: String) {
+//            self.value = value
+//        }
+//
+//        required init() {
+//            self.value = ""
+//        }
+//    }
+//}
+//
+//// MARK: -
+//
+//class StateComponentMappingTests: XCTestCase {
+//    func testAddReturnsSameMappingForSameComponentType() {
+//        let state = EntityState()
+//        let mapping = state.addMapping(for: MockComponent.self)
+//        XCTAssertFalse(mapping === mapping.add(MockComponent.self))
+//    }
+//
+//    func testAddReturnsSameMappingForDifferentComponentTypes() {
+//        let state = EntityState()
+//        let mapping = state.addMapping(for: MockComponent.self)
+//        XCTAssertFalse(mapping === mapping.add(MockComponent2.self))
+//    }
+//
+//    func testAddAddsProviderToState() {
+//        let state = EntityState()
+//        let mapping = state.addMapping(for: MockComponent.self)
+//        mapping.add(MockComponent2.self)
+//        XCTAssertTrue(state.hasProvider(for: MockComponent.self))
+//    }
+//
+//    class MockComponent: ComponentInitializable {
+//        let value: Int
+//
+//        init(value: Int) {
+//            self.value = value
+//        }
+//
+//        required init() {
+//            self.value = 0
+//        }
+//    }
+//
+//    class MockComponent2: ComponentInitializable {
+//        let value: String
+//
+//        init(value: String) {
+//            self.value = value
+//        }
+//
+//        required init() {
+//            self.value = ""
+//        }
+//    }
+//}


### PR DESCRIPTION
### Description

This PR aims to address the current performance and thread-safety limitations of the ECS by switching to using value type components. This allows better memory usage patterns, better performance, easier thread safety, and opens up many possible alleys for improvement (such as creating a system scheduler that analyses read and write dependencies between systems to automatically run systems in parallel where possible).

### Detailed Design

These changes will overhaul massive portions of the API and will likely warrant a bump of the major version.

Here are the main tasks to be completed:

- [x] Remove `AnyObject` conformance from `Component` protocol
- [ ] Update Nexus API to add methods for mutating components
- [ ] Simplify the nexus API to enhance maintainability (there are lots of unnecessary methods that could probably be removed, what's your opinion on this @ctreffs? my main rationale behind simplifying the API is that it seems pretty difficult to maintain when there are so many methods to update)
- [ ] Implement read-only and read-write families

#### Possible future optimisations

After implementing the basis of value type components there are many optimisations that can be implemented.
  
- [ ] Allow families to have a mixture of read-only and read-write components
- [ ] Create a `System` API to formalise how systems should be declared in a type-safe and thread-safe manner
- [ ] Create a `TickScheduler` API which can run systems in a specified order and maybe even run systems in parallel when they are identified to have no common dependencies  

#### Swift limitations

The main limitation that I have identified so far is that there isn't a way (that I know of) to restrict a protocol to only value types (unlike restricting to reference types which is possible with `AnyObject`. The only workaround I can see for this is putting advice all throughout the documentation saying to use value types for components. It technically shouldn't break the ECS if a component is a reference type, however it breaks a lot of thread-safety guarantees and would probably make for pretty confusing code.

### Testing

Once I am finished, I will make sure that all the tests pass and, most importantly, are still valid with the new component semantics. Currently they all pass but they most definitely shouldn't.

### Source Impact

This will break every single package which depends on the ECS.

### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/fireblade-engine/ecs/blob/master/CONTRIBUTING.md)
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (to the extent possible).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [ ] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
- [ ] I've updated the documentation (if appropriate).
