### PR TITLE
marks sourcery stencils as excluded from swiftpm processing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,9 +8,11 @@ let package = Package(
                  targets: ["FirebladeECS"])
     ],
     targets: [
-        .target(name: "FirebladeECS"),
+        .target(name: "FirebladeECS",
+                exclude: ["Stencils/Family.stencil"]),
         .testTarget(name: "FirebladeECSTests",
-                    dependencies: ["FirebladeECS"]),
+                    dependencies: ["FirebladeECS"],
+                    exclude: ["Stencils/FamilyTests.stencil"]),
         .testTarget(name: "FirebladeECSPerformanceTests",
                     dependencies: ["FirebladeECS"])
     ],


### PR DESCRIPTION
### Description

Cleanup work - after moving to Swift 5.8 tools, extraneous files throw warnings. This adds declarations in the Package.swift to exclude the stencil files from SwiftPM processing.

### Source Impact

None

### Checklist

- [X] I've read the [Contribution Guidelines](https://github.com/fireblade-engine/ecs/blob/master/CONTRIBUTING.md)
- [X] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (to the extent possible).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [X] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
- [ ] I've updated the documentation (if appropriate).
