### PR TITLE
switches runs-on target to pull-request-target

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -3,7 +3,7 @@ name: macOS
 on:
   push:
     branches: [ master ]
-  pull_request:
+  pull_request_target:
     branches: [ master ]
 
 jobs:


### PR DESCRIPTION

### Description

This change gives PR runs access to secrets - needed for uploading the code coverage details when run from a fork.

### Detailed Design

there's a bit of extended conversation on this detail at https://stackoverflow.com/questions/74957218/what-is-the-difference-between-pull-request-and-pull-request-target-event-in-git, but the gist is that with this change, any code invoked through a pull request has access to the repositories' secrets. As far as I could see from the workflows on this repository, the only real notable secret is the CODECOV token for uploading code coverage, so I think this is a potentially meaningful change. 

We'll see if it fails the CI though, which I'd expect if that doesn't "do the trick" for the macOS specific builds.
In either case, it probably isn't 100% sensible to upload the code coverage 3 times - one for each of the matrix of builds, so that may be worth refactoring to pick one as the "code coverage" build, and do the others from the matrix without attempting to upload code coverage.

### Testing

*How is the new feature tested?*

Pretty much just workin' the CI system in this case, since that's the system being adjusted.

### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/fireblade-engine/ecs/blob/master/CONTRIBUTING.md)
