### PR TITLE
Add support for fork PR workflows

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -8,6 +8,7 @@ on:
   workflow_dispatch:
 
 env:
+  CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   CODECOV_XCODE_VERSION: "15.4"  # Xcode version used to generate code coverage
 
 jobs:
@@ -47,13 +48,13 @@ jobs:
 
       # Only run coverage steps if the CODECOV_TOKEN is available and the matrix.xcode matches CODECOV_XCODE_VERSION
       - name: Generate coverage report
-        if: secrets.CODECOV_TOKEN != '' && matrix.xcode == env.CODECOV_XCODE_VERSION
+        if: env.CODECOV_TOKEN != '' && matrix.xcode == env.CODECOV_XCODE_VERSION
         run: xcrun llvm-cov export -format="lcov" .build/**/*PackageTests.xctest/Contents/MacOS/*PackageTests -instr-profile .build/**/codecov/default.profdata > coverage.lcov
 
       - name: Upload code coverage report
-        if: secrets.CODECOV_TOKEN != '' && matrix.xcode == env.CODECOV_XCODE_VERSION
+        if: env.CODECOV_TOKEN != '' && matrix.xcode == env.CODECOV_XCODE_VERSION
         uses: codecov/codecov-action@v4.6.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           file: coverage.lcov
           fail_ci_if_error: true

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -5,6 +5,10 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
+
+env:
+  CODECOV_XCODE_VERSION: "15.4"  # Xcode version used to generate code coverage
 
 jobs:
   macos-test-build-release-xcode:
@@ -12,15 +16,19 @@ jobs:
     strategy:
       matrix:
         xcode: ["14.3.1", "15.4", "16.0"]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
       - name: Select Xcode ${{ matrix.xcode }}
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+
       - name: Test
         run: swift test -c release --parallel --xunit-output .build/xUnit-output.xml --enable-code-coverage
         env:
           DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+
       - name: Upload test artifacts
         if: failure()
         uses: actions/upload-artifact@v4.4.2
@@ -37,9 +45,13 @@ jobs:
           if-no-files-found: warn
           include-hidden-files: true
 
+      # Only run coverage steps if the CODECOV_TOKEN is available and the matrix.xcode matches CODECOV_XCODE_VERSION
       - name: Generate coverage report
+        if: secrets.CODECOV_TOKEN != '' && matrix.xcode == env.CODECOV_XCODE_VERSION
         run: xcrun llvm-cov export -format="lcov" .build/**/*PackageTests.xctest/Contents/MacOS/*PackageTests -instr-profile .build/**/codecov/default.profdata > coverage.lcov
+
       - name: Upload code coverage report
+        if: secrets.CODECOV_TOKEN != '' && matrix.xcode == env.CODECOV_XCODE_VERSION
         uses: codecov/codecov-action@v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Description

- Runs code coverage only if secret is available
- Generates code coverage once for macOS jobs (Xcode 15.4 for now)
- Adds manual triggers to workflows

If the job as access to `secrets.*` code coverage is generated and updated as seen here:
https://github.com/fireblade-engine/ecs/actions/runs/11270655550/job/31341844789

if the job does not have access to `secrets.*` code coverage is skipped as can be seen here:
https://github.com/fireblade-engine/ecs/actions/runs/11270558859/job/31341683160

This was tested with PR #72 and the current PR #71

### Checklist

- [x] I've read the [Contribution Guidelines](https://github.com/fireblade-engine/ecs/blob/master/CONTRIBUTING.md)
- [x] I've followed the coding style of the rest of the project.
- [ ] I've added tests covering all new code paths my change adds to the project (to the extent possible).
- [ ] I've added benchmarks covering new functionality (if appropriate).
- [x] I've verified that my change does not break any existing tests or introduce unexpected benchmark regressions.
- [ ] I've updated the documentation (if appropriate).
