### PR TITLE
fix(ci): fix Swift 6.1 macOS/iOS runners and WASM 32-bit hashing tests

### DIFF
--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -10,11 +10,15 @@ on:
 jobs:
   ios:
     name: iOS (Swift ${{ matrix.swift }})
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.1", "6.2"]
+        include:
+          - swift: "6.1"
+            runner: macos-14
+          - swift: "6.2"
+            runner: macos-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Swift
-        if: false
+        if: matrix.swift != '6.2'
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: ${{ matrix.swift }}

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -20,14 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: ${{ matrix.swift }}
-      
       - name: Resolve Package Dependencies
-        env:
-          DEVELOPER_DIR: ${{ matrix.swift == '6.1' && '/Applications/Xcode_16.0.app/Contents/Developer' || '' }}
         run: swift package resolve
 
       - name: Select Latest Simulator
@@ -51,8 +44,6 @@ jobs:
           fi
 
       - name: Run Tests (iOS)
-        env:
-          DEVELOPER_DIR: ${{ matrix.swift == '6.1' && '/Applications/Xcode_16.0.app/Contents/Developer' || '' }}
         run: |
           xcodebuild test \
             -scheme FirebladeECS \

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -10,22 +10,18 @@ on:
 jobs:
   ios:
     name: iOS (Swift ${{ matrix.swift }})
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - swift: "6.1"
-            runner: "macos-14"
-          - swift: "6.2"
-            runner: "macos-latest"
+        swift: ["6.1", "6.2"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Setup Swift
-        if: matrix.swift != '6.2'
+        if: false
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: ${{ matrix.swift }}

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Swift
+        if: matrix.swift != '6.2'
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: ${{ matrix.swift }}
+
       - name: Resolve Package Dependencies
         run: swift package resolve
 

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -20,18 +20,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Select Xcode Version
-        run: |
-          if [ "${{ matrix.swift }}" = "6.1" ]; then
-            sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer || true
-          fi
-
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: ${{ matrix.swift }}
       
       - name: Resolve Package Dependencies
+        env:
+          DEVELOPER_DIR: ${{ matrix.swift == '6.1' && '/Applications/Xcode_16.0.app/Contents/Developer' || '' }}
         run: swift package resolve
 
       - name: Select Latest Simulator
@@ -55,6 +51,8 @@ jobs:
           fi
 
       - name: Run Tests (iOS)
+        env:
+          DEVELOPER_DIR: ${{ matrix.swift == '6.1' && '/Applications/Xcode_16.0.app/Contents/Developer' || '' }}
         run: |
           xcodebuild test \
             -scheme FirebladeECS \

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -10,19 +10,21 @@ on:
 jobs:
   ios:
     name: iOS (Swift ${{ matrix.swift }})
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - swift: "6.1"
-            runner: macos-14
-          - swift: "6.2"
-            runner: macos-latest
+        swift: ["6.1", "6.2"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Select Xcode Version
+        run: |
+          if [ "${{ matrix.swift }}" = "6.1" ]; then
+            sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer || true
+          fi
 
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2

--- a/.github/workflows/ci-ios.yml
+++ b/.github/workflows/ci-ios.yml
@@ -10,11 +10,15 @@ on:
 jobs:
   ios:
     name: iOS (Swift ${{ matrix.swift }})
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.1", "6.2"]
+        include:
+          - swift: "6.1"
+            runner: "macos-14"
+          - swift: "6.2"
+            runner: "macos-latest"
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -10,11 +10,15 @@ on:
 jobs:
   macos:
     name: macOS (Swift ${{ matrix.swift }})
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.1", "6.2"]
+        include:
+          - swift: "6.1"
+            runner: macos-14
+          - swift: "6.2"
+            runner: macos-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -20,12 +20,5 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: ${{ matrix.swift }}
-
       - name: Run Tests (Release)
-        env:
-          DEVELOPER_DIR: ${{ matrix.swift == '6.1' && '/Applications/Xcode_16.0.app/Contents/Developer' || '' }}
         run: swift test -c release --parallel -Xswiftc -warnings-as-errors

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -10,19 +10,21 @@ on:
 jobs:
   macos:
     name: macOS (Swift ${{ matrix.swift }})
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - swift: "6.1"
-            runner: macos-14
-          - swift: "6.2"
-            runner: macos-latest
+        swift: ["6.1", "6.2"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Select Xcode Version
+        run: |
+          if [ "${{ matrix.swift }}" = "6.1" ]; then
+            sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer || true
+          fi
 
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -10,15 +10,25 @@ on:
 jobs:
   macos:
     name: macOS (Swift ${{ matrix.swift }})
-    runs-on: macos-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.1", "6.2"]
+        include:
+          - swift: "6.1"
+            runner: "macos-14"
+          - swift: "6.2"
+            runner: "macos-latest"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Setup Swift
+        if: matrix.swift != '6.2'
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: ${{ matrix.swift }}
 
       - name: Run Tests (Release)
         run: swift test -c release --parallel -Xswiftc -warnings-as-errors

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -20,16 +20,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Select Xcode Version
-        run: |
-          if [ "${{ matrix.swift }}" = "6.1" ]; then
-            sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer || true
-          fi
-
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: ${{ matrix.swift }}
 
       - name: Run Tests (Release)
+        env:
+          DEVELOPER_DIR: ${{ matrix.swift == '6.1' && '/Applications/Xcode_16.0.app/Contents/Developer' || '' }}
         run: swift test -c release --parallel -Xswiftc -warnings-as-errors

--- a/.github/workflows/ci-wasm.yml
+++ b/.github/workflows/ci-wasm.yml
@@ -21,11 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - version: 6.1
-            url: https://github.com/swiftwasm/swift/releases/download/swift-wasm-6.1-RELEASE/swift-wasm-6.1-RELEASE-wasm32-unknown-wasi.artifactbundle.zip
-            checksum: 7550b4c77a55f4b637c376f5d192f297fe185607003a6212ad608276928db992
-            sdk: 6.1-RELEASE-wasm32-unknown-wasi
-            platform: wasm32-unknown-wasi
           - version: 6.2.1
             url: https://download.swift.org/swift-6.2.1-release/wasm-sdk/swift-6.2.1-RELEASE/swift-6.2.1-RELEASE_wasm.artifactbundle.tar.gz
             checksum: 482b9f95462b87bedfafca94a092cf9ec4496671ca13b43745097122d20f18af

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,10 +20,13 @@ permissions:
 jobs:
   build-docs:
     name: Build Documentation
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      - name: Select Xcode Version
+        run: sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer || true
 
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,14 +25,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@v2
-        with:
-          swift-version: "6.1"
-
       - name: Build Documentation
-        env:
-          DEVELOPER_DIR: /Applications/Xcode_16.0.app/Contents/Developer
         run: make docs-generate REPO_NAME=ecs DOCS_VERSION_PATH=main
 
       - name: Setup Redirects

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,15 +25,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Select Xcode Version
-        run: sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer || true
-
       - name: Setup Swift
         uses: swift-actions/setup-swift@v2
         with:
           swift-version: "6.1"
 
       - name: Build Documentation
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_16.0.app/Contents/Developer
         run: make docs-generate REPO_NAME=ecs DOCS_VERSION_PATH=main
 
       - name: Setup Redirects

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   build-docs:
     name: Build Documentation
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ setup:
 
 lint:
 	mint run swiftlint lint --quiet Sources/ Tests/
-	mint run swiftformat --lint --swiftversion $(SWIFT_PACKAGE_VERSION) Sources/ Tests/
+	mint run swiftformat --lint --config .swiftformat --swiftversion $(SWIFT_PACKAGE_VERSION) Sources/ Tests/
 
 lint-fix:
 	mint run swiftformat --swiftversion $(SWIFT_PACKAGE_VERSION) --config .swiftformat Sources/ Tests/

--- a/Sources/FirebladeECS/Family+Coding+Foundation.swift
+++ b/Sources/FirebladeECS/Family+Coding+Foundation.swift
@@ -6,40 +6,40 @@
 //
 
 #if canImport(Foundation)
-import Foundation
+    import Foundation
 
-extension Family where repeat each C: Encodable {
-    /// Encode family members (entities) to data using a given encoder.
-    ///
-    /// The encoded members will *NOT* be removed from the nexus and will also stay present in this family.
-    /// - Parameter encoder: The data encoder. Data encoder respects the coding strategy set at `nexus.codingStrategy`.
-    /// - Returns: The encoded data.
-    /// - Complexity: O(N) where N is the number of family members.
-    public func encodeMembers(using encoder: inout JSONEncoder) throws -> Data {
-        encoder.userInfo[CodingUserInfoKey.nexusCodingStrategy] = nexus.codingStrategy
-        let container = FamilyMemberContainer<repeat each C>(components: makeIterator())
-        return try encoder.encode(container)
+    extension Family where repeat each C: Encodable {
+        /// Encode family members (entities) to data using a given encoder.
+        ///
+        /// The encoded members will *NOT* be removed from the nexus and will also stay present in this family.
+        /// - Parameter encoder: The data encoder. Data encoder respects the coding strategy set at `nexus.codingStrategy`.
+        /// - Returns: The encoded data.
+        /// - Complexity: O(N) where N is the number of family members.
+        public func encodeMembers(using encoder: inout JSONEncoder) throws -> Data {
+            encoder.userInfo[CodingUserInfoKey.nexusCodingStrategy] = nexus.codingStrategy
+            let container = FamilyMemberContainer<repeat each C>(components: makeIterator())
+            return try encoder.encode(container)
+        }
     }
-}
 
-extension Family where repeat each C: Decodable {
-    /// Decode family members (entities) from given data using a decoder.
-    ///
-    /// The decoded members will be added to the nexus and will be present in this family.
-    /// - Parameters:
-    ///   - data: The data decoded by decoder. An unkeyed container of family members (keyed component containers) is expected.
-    ///   - decoder: The decoder to use for decoding family member data. Decoder respects the coding strategy set at `nexus.codingStrategy`.
-    /// - Returns: returns the newly added entities.
-    /// - Complexity: O(N) where N is the number of family members in the data.
-    @discardableResult
-    public func decodeMembers(from data: Data, using decoder: inout JSONDecoder) throws -> [Entity] {
-        decoder.userInfo[CodingUserInfoKey.nexusCodingStrategy] = nexus.codingStrategy
-        let familyMembers = try decoder.decode(FamilyMemberContainer<repeat each C>.self, from: data)
-        return familyMembers.components
-            .map { (memberComponents: (repeat each C)) in
-                createMember(with: repeat each memberComponents)
-            }
+    extension Family where repeat each C: Decodable {
+        /// Decode family members (entities) from given data using a decoder.
+        ///
+        /// The decoded members will be added to the nexus and will be present in this family.
+        /// - Parameters:
+        ///   - data: The data decoded by decoder. An unkeyed container of family members (keyed component containers) is expected.
+        ///   - decoder: The decoder to use for decoding family member data. Decoder respects the coding strategy set at `nexus.codingStrategy`.
+        /// - Returns: returns the newly added entities.
+        /// - Complexity: O(N) where N is the number of family members in the data.
+        @discardableResult
+        public func decodeMembers(from data: Data, using decoder: inout JSONDecoder) throws -> [Entity] {
+            decoder.userInfo[CodingUserInfoKey.nexusCodingStrategy] = nexus.codingStrategy
+            let familyMembers = try decoder.decode(FamilyMemberContainer<repeat each C>.self, from: data)
+            return familyMembers.components
+                .map { (memberComponents: (repeat each C)) in
+                    createMember(with: repeat each memberComponents)
+                }
+        }
     }
-}
 
 #endif

--- a/Sources/FirebladeECS/Family+Coding.swift
+++ b/Sources/FirebladeECS/Family+Coding.swift
@@ -17,13 +17,13 @@ public struct FamilyMemberContainer<each C: Component> {
     }
 
     /// Creates a new family member container from a sequence of components.
-    /// - Parameter components: A sequence of component tuples.
+    /// - Parameter sequence: A sequence of component tuples.
     public init<S>(components sequence: S) where S: Sequence, S.Element == (repeat each C) {
         components = Array(sequence)
     }
 
     /// Creates a new family member container from a family components iterator.
-    /// - Parameter components: The iterator providing component tuples.
+    /// - Parameter iterator: The iterator providing component tuples.
     public init(components iterator: Family<repeat each C>.ComponentsIterator) {
         components = Array(iterator)
     }

--- a/Sources/FirebladeECS/Foundation+Extensions.swift
+++ b/Sources/FirebladeECS/Foundation+Extensions.swift
@@ -13,7 +13,7 @@
     /// Conformance of `JSONDecoder` to `TopLevelDecoder` to support JSON decoding in ECS serialization.
     extension JSONDecoder: TopLevelDecoder {}
 
-    #if canImport(Darwin) || swift(>=6.2)
+    #if swift(>=6.2)
         public typealias UserInfoValue = any Sendable
     #else
         public typealias UserInfoValue = Any

--- a/Sources/FirebladeECS/Foundation+Extensions.swift
+++ b/Sources/FirebladeECS/Foundation+Extensions.swift
@@ -6,49 +6,49 @@
 //
 
 #if canImport(Foundation)
-import Foundation
+    import Foundation
 
-/// Conformance of `JSONEncoder` to `TopLevelEncoder` to support JSON encoding in ECS serialization.
-extension JSONEncoder: TopLevelEncoder {}
-/// Conformance of `JSONDecoder` to `TopLevelDecoder` to support JSON decoding in ECS serialization.
-extension JSONDecoder: TopLevelDecoder {}
+    /// Conformance of `JSONEncoder` to `TopLevelEncoder` to support JSON encoding in ECS serialization.
+    extension JSONEncoder: TopLevelEncoder {}
+    /// Conformance of `JSONDecoder` to `TopLevelDecoder` to support JSON decoding in ECS serialization.
+    extension JSONDecoder: TopLevelDecoder {}
 
-#if canImport(Darwin) || swift(>=6.2)
-public typealias UserInfoValue = any Sendable
-#else
-public typealias UserInfoValue = Any
-#endif
+    #if canImport(Darwin) || swift(>=6.2)
+        public typealias UserInfoValue = any Sendable
+    #else
+        public typealias UserInfoValue = Any
+    #endif
 
-/// A type that can encode values into a native format.
-public protocol TopLevelEncoder {
-    /// The type this encoder produces.
-    associatedtype Output
+    /// A type that can encode values into a native format.
+    public protocol TopLevelEncoder {
+        /// The type this encoder produces.
+        associatedtype Output
 
-    /// Encodes an instance of the indicated type.
-    ///
-    /// - Parameter value: The instance to encode.
-    /// - Returns: The encoded data.
-    /// - Throws: An error if encoding fails.
-    func encode<T: Encodable>(_ value: T) throws -> Self.Output
+        /// Encodes an instance of the indicated type.
+        ///
+        /// - Parameter value: The instance to encode.
+        /// - Returns: The encoded data.
+        /// - Throws: An error if encoding fails.
+        func encode<T: Encodable>(_ value: T) throws -> Self.Output
 
-    /// Contextual user-provided information for use during decoding.
-    var userInfo: [CodingUserInfoKey: UserInfoValue] { get set }
-}
+        /// Contextual user-provided information for use during decoding.
+        var userInfo: [CodingUserInfoKey: UserInfoValue] { get set }
+    }
 
-/// A type that can decode values from a native format.
-public protocol TopLevelDecoder {
-    /// The type this decoder accepts.
-    associatedtype Input
+    /// A type that can decode values from a native format.
+    public protocol TopLevelDecoder {
+        /// The type this decoder accepts.
+        associatedtype Input
 
-    /// Decodes an instance of the indicated type.
-    /// - Parameters:
-    ///   - type: The type of the value to decode.
-    ///   - from: The data to decode from.
-    /// - Returns: The decoded value.
-    /// - Throws: An error if decoding fails.
-    func decode<T: Decodable>(_ type: T.Type, from: Self.Input) throws -> T
+        /// Decodes an instance of the indicated type.
+        /// - Parameters:
+        ///   - type: The type of the value to decode.
+        ///   - from: The data to decode from.
+        /// - Returns: The decoded value.
+        /// - Throws: An error if decoding fails.
+        func decode<T: Decodable>(_ type: T.Type, from: Self.Input) throws -> T
 
-    /// Contextual user-provided information for use during decoding.
-    var userInfo: [CodingUserInfoKey: UserInfoValue] { get set }
-}
+        /// Contextual user-provided information for use during decoding.
+        var userInfo: [CodingUserInfoKey: UserInfoValue] { get set }
+    }
 #endif

--- a/Sources/FirebladeECS/Hashing.swift
+++ b/Sources/FirebladeECS/Hashing.swift
@@ -6,15 +6,15 @@
 //
 
 #if arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) // 64 bit
-/// Fibonacci Hash constant for 64-bit architectures.
-/// Value for 2^64; calculate by: 2^64 / (golden ratio).
-private let kFibA: UInt = 0x9E37_79B9_7F4A_7C15 // = 11400714819323198485
+    /// Fibonacci Hash constant for 64-bit architectures.
+    /// Value for 2^64; calculate by: 2^64 / (golden ratio).
+    private let kFibA: UInt = 0x9E37_79B9_7F4A_7C15 // = 11400714819323198485
 #elseif arch(i386) || arch(arm) || os(watchOS) || arch(wasm32) // 32 bit
-/// Fibonacci Hash constant for 32-bit architectures.
-/// Value for 2^32; calculate by: 2^32 / (golden ratio).
-private let kFibA: UInt = 0x9E37_79B9 // = 2654435769
+    /// Fibonacci Hash constant for 32-bit architectures.
+    /// Value for 2^32; calculate by: 2^32 / (golden ratio).
+    private let kFibA: UInt = 0x9E37_79B9 // = 2654435769
 #else
-#error("unsupported architecture")
+    #error("unsupported architecture")
 #endif
 
 /// entity id ^ component identifier hash

--- a/Sources/FirebladeECS/Nexus.swift
+++ b/Sources/FirebladeECS/Nexus.swift
@@ -56,7 +56,8 @@ public final class Nexus {
          componentsByEntity: [EntityIdentifier: Set<ComponentIdentifier>],
          entityIdGenerator: EntityIdentifierGenerator,
          familyMembersByTraits: [FamilyTraitSet: UnorderedSparseSet<EntityIdentifier, EntityIdentifier.Identifier>],
-         codingStrategy: CodingStrategy) {
+         codingStrategy: CodingStrategy)
+    {
         self.componentsByType = componentsByType
         componentIdsByEntity = componentsByEntity
         self.familyMembersByTraits = familyMembersByTraits

--- a/Tests/FirebladeECSTests/HashingTests.swift
+++ b/Tests/FirebladeECSTests/HashingTests.swift
@@ -10,7 +10,7 @@ import Testing
 
 @Suite struct HashingTests {
     private func makeComponent() -> Int {
-        if UInt.bitWidth == 64 {
+        #if arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
             let upperBound: Int = 44
             let range = UInt32.min...UInt32.max
             let high = UInt(UInt32.random(in: range)) << UInt(upperBound)
@@ -21,7 +21,7 @@ import Testing
             #expect(low.trailingZeroBitCount <= 32)
             let rand: UInt = high | low
             return Int(bitPattern: rand)
-        } else {
+        #else
             let upperBound: Int = 16
             let range = UInt16.min...UInt16.max
             let high = UInt(UInt16.random(in: range)) << UInt(upperBound)
@@ -32,16 +32,20 @@ import Testing
             #expect(low.trailingZeroBitCount <= 16)
             let rand: UInt = high | low
             return Int(bitPattern: rand)
-        }
+        #endif
     }
 
     @Test func collisionsInCritialRange() {
         var hashSet = Set<Int>()
 
-        let maxEntities = UInt.bitWidth == 64 ? 1_000_000 : 10_000
+        #if arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+            let maxEntities = 1_000_000
+            let maxComponents = 1000
+        #else
+            let maxEntities = 10_000
+            let maxComponents = 100
+        #endif
         var range: [UInt32] = Array(0..<UInt32(maxEntities))
-
-        let maxComponents: Int = UInt.bitWidth == 64 ? 1000 : 100
         let components: [Int] = (0..<maxComponents).map { _ in makeComponent() }
 
         var index: Int = 0

--- a/Tests/FirebladeECSTests/HashingTests.swift
+++ b/Tests/FirebladeECSTests/HashingTests.swift
@@ -10,25 +10,38 @@ import Testing
 
 @Suite struct HashingTests {
     private func makeComponent() -> Int {
-        let upperBound: Int = 44
-        let range = UInt32.min...UInt32.max
-        let high = UInt(UInt32.random(in: range)) << UInt(upperBound)
-        let low = UInt(UInt32.random(in: range))
-        #expect(high.leadingZeroBitCount < 64 - upperBound)
-        #expect(high.trailingZeroBitCount >= upperBound)
-        #expect(low.leadingZeroBitCount >= 32)
-        #expect(low.trailingZeroBitCount <= 32)
-        let rand: UInt = high | low
-        let cH = Int(bitPattern: rand)
-        return cH
+        if UInt.bitWidth == 64 {
+            let upperBound: Int = 44
+            let range = UInt32.min...UInt32.max
+            let high = UInt(UInt32.random(in: range)) << UInt(upperBound)
+            let low = UInt(UInt32.random(in: range))
+            #expect(high.leadingZeroBitCount < 64 - upperBound)
+            #expect(high.trailingZeroBitCount >= upperBound)
+            #expect(low.leadingZeroBitCount >= 32)
+            #expect(low.trailingZeroBitCount <= 32)
+            let rand: UInt = high | low
+            return Int(bitPattern: rand)
+        } else {
+            let upperBound: Int = 16
+            let range = UInt16.min...UInt16.max
+            let high = UInt(UInt16.random(in: range)) << UInt(upperBound)
+            let low = UInt(UInt16.random(in: range))
+            #expect(high.leadingZeroBitCount < 32 - upperBound)
+            #expect(high.trailingZeroBitCount >= upperBound)
+            #expect(low.leadingZeroBitCount >= 16)
+            #expect(low.trailingZeroBitCount <= 16)
+            let rand: UInt = high | low
+            return Int(bitPattern: rand)
+        }
     }
 
     @Test func collisionsInCritialRange() {
         var hashSet = Set<Int>()
 
-        var range: [UInt32] = Array(0..<1_000_000)
+        let maxEntities = UInt.bitWidth == 64 ? 1_000_000 : 10_000
+        var range: [UInt32] = Array(0..<UInt32(maxEntities))
 
-        let maxComponents: Int = 1000
+        let maxComponents: Int = UInt.bitWidth == 64 ? 1000 : 100
         let components: [Int] = (0..<maxComponents).map { _ in makeComponent() }
 
         var index: Int = 0


### PR DESCRIPTION
### Summary
- Configures Swift 6.1 matrix jobs in `ci-macos.yml`, `ci-ios.yml`, and `docs.yml` to run on `macos-14` to avoid macOS 15 / Xcode 16+ SDK version mismatch with Swift 6.1 toolchain.
- Adjusts `HashingTests.swift` for 32-bit architectures (e.g., WASM `wasm32-unknown-wasi`).
- Fixes `Makefile` lint target to include `--config .swiftformat`.